### PR TITLE
fix(tobii-service): use camelCase for all API responses

### DIFF
--- a/tobii-service/API.md
+++ b/tobii-service/API.md
@@ -23,10 +23,10 @@ Web App (Browser) ──WebSocket──> Lexora Service (localhost:28980) ──
 {
   "connected": true,
   "device": {
-    "device_name": "Tobii Pro Fusion",
-    "serial_number": "TPC-0123456789AB",
+    "deviceName": "Tobii Pro Fusion",
+    "serialNumber": "TPC-0123456789AB",
     "model": "Tobii Pro Fusion",
-    "firmware_version": "1.7.6-citronkola-ibland.6"
+    "firmwareVersion": "1.7.6-citronkola-ibland.6"
   }
 }
 ```
@@ -53,13 +53,13 @@ When no device is connected:
 ```json
 [
   {
-    "fixation_x": 0.5,
-    "fixation_y": 0.5,
+    "fixationX": 0.5,
+    "fixationY": 0.5,
     "timestamp": 1234567890123456
   },
   {
-    "fixation_x": 0.51,
-    "fixation_y": 0.49,
+    "fixationX": 0.51,
+    "fixationY": 0.49,
     "timestamp": 1234567890140000
   }
 ]
@@ -71,13 +71,13 @@ When no device is connected:
 - Batches sent approximately every 50ms
 
 **Field Descriptions:**
-- `fixation_x`, `fixation_y`: Averaged gaze coordinates from both eyes (normalized 0.0 to 1.0)
+- `fixationX`, `fixationY`: Averaged gaze coordinates from both eyes (normalized 0.0 to 1.0)
 - `timestamp`: System timestamp in **microseconds** (integer, not milliseconds)
 
 **Coordinate System:**
 - Normalized coordinates (0.0 to 1.0)
-- `fixation_x: 0.0` = left edge of screen, `fixation_x: 1.0` = right edge
-- `fixation_y: 0.0` = top edge of screen, `fixation_y: 1.0` = bottom edge
+- `fixationX: 0.0` = left edge of screen, `fixationX: 1.0` = right edge
+- `fixationY: 0.0` = top edge of screen, `fixationY: 1.0` = bottom edge
 
 **Frequency:** Depends on the Tobii Pro device (typically 60Hz, 120Hz, 250Hz, or higher)
 
@@ -131,8 +131,8 @@ class EyeTrackerClient {
     // Process array of gaze points
     gazePoints.forEach(point => {
       // Convert normalized coordinates to screen pixels
-      const screenX = point.fixation_x * window.innerWidth;
-      const screenY = point.fixation_y * window.innerHeight;
+      const screenX = point.fixationX * window.innerWidth;
+      const screenY = point.fixationY * window.innerHeight;
       
       // Your application logic here
       console.log(`Gaze at: (${screenX}, ${screenY})`);
@@ -166,8 +166,8 @@ tracker.checkStatus().then(connected => {
 import { useEffect, useRef, useState } from 'react';
 
 interface GazePoint {
-  fixation_x: number;
-  fixation_y: number;
+  fixationX: number;
+  fixationY: number;
   timestamp: number;
 }
 
@@ -242,8 +242,8 @@ function MyComponent() {
       <p>Eye tracking active</p>
       {gazePoints.length > 0 && (
         <p>
-          Latest gaze: ({gazePoints[gazePoints.length - 1].fixation_x.toFixed(3)}, 
-          {gazePoints[gazePoints.length - 1].fixation_y.toFixed(3)})
+          Latest gaze: ({gazePoints[gazePoints.length - 1].fixationX.toFixed(3)}, 
+          {gazePoints[gazePoints.length - 1].fixationY.toFixed(3)})
         </p>
       )}
     </div>
@@ -372,10 +372,10 @@ class GazeSmoothing {
       this.buffer.shift();
     }
 
-    const avgX = this.buffer.reduce((sum, p) => sum + p.fixation_x, 0) / this.buffer.length;
-    const avgY = this.buffer.reduce((sum, p) => sum + p.fixation_y, 0) / this.buffer.length;
+    const avgX = this.buffer.reduce((sum, p) => sum + p.fixationX, 0) / this.buffer.length;
+    const avgY = this.buffer.reduce((sum, p) => sum + p.fixationY, 0) / this.buffer.length;
 
-    return { fixation_x: avgX, fixation_y: avgY };
+    return { fixationX: avgX, fixationY: avgY };
   }
 }
 
@@ -397,8 +397,8 @@ ws.onmessage = (event) => {
 function toScreenCoordinates(gazePoint, element = document.body) {
   const rect = element.getBoundingClientRect();
   return {
-    x: gazePoint.fixation_x * rect.width + rect.left,
-    y: gazePoint.fixation_y * rect.height + rect.top
+    x: gazePoint.fixationX * rect.width + rect.left,
+    y: gazePoint.fixationY * rect.height + rect.top
   };
 }
 ```
@@ -466,13 +466,13 @@ class MockEyeTracker {
       // Simulate batch of gaze data (like real service)
       const mockBatch = [
         {
-          fixation_x: 0.4 + Math.random() * 0.2,
-          fixation_y: 0.4 + Math.random() * 0.2,
+          fixationX: 0.4 + Math.random() * 0.2,
+          fixationY: 0.4 + Math.random() * 0.2,
           timestamp: Date.now() * 1000 // Convert to microseconds
         },
         {
-          fixation_x: 0.4 + Math.random() * 0.2,
-          fixation_y: 0.4 + Math.random() * 0.2,
+          fixationX: 0.4 + Math.random() * 0.2,
+          fixationY: 0.4 + Math.random() * 0.2,
           timestamp: Date.now() * 1000 + 16000 // ~16ms later
         }
       ];

--- a/tobii-service/README.md
+++ b/tobii-service/README.md
@@ -86,10 +86,10 @@ Returns tracker information:
 {
   "connected": true,
   "device": {
-    "device_name": "Tobii Pro Fusion",
-    "serial_number": "TPC-0123456789AB",
+    "deviceName": "Tobii Pro Fusion",
+    "serialNumber": "TPC-0123456789AB",
     "model": "Tobii Pro Fusion",
-    "firmware_version": "1.7.6-citronkola-ibland.6"
+    "firmwareVersion": "1.7.6-citronkola-ibland.6"
   }
 }
 ```
@@ -105,20 +105,20 @@ Receives batches of gaze points (array):
 ```json
 [
   {
-    "fixation_x": 0.5,
-    "fixation_y": 0.5,
+    "fixationX": 0.5,
+    "fixationY": 0.5,
     "timestamp": 1234567890123456
   },
   {
-    "fixation_x": 0.51,
-    "fixation_y": 0.49,
+    "fixationX": 0.51,
+    "fixationY": 0.49,
     "timestamp": 1234567890140000
   }
 ]
 ```
 
 **Data format:**
-- `fixation_x`, `fixation_y`: Averaged gaze coordinates from both eyes (normalized 0.0 to 1.0)
+- `fixationX`, `fixationY`: Averaged gaze coordinates from both eyes (normalized 0.0 to 1.0)
 - `timestamp`: System timestamp in **microseconds** (not milliseconds)
 - Coordinates: `x: 0.0` = left edge, `x: 1.0` = right edge; `y: 0.0` = top edge, `y: 1.0` = bottom edge
 - Response is an **array** of gaze points collected since last message (~50ms batches)
@@ -137,7 +137,7 @@ ws.onmessage = (event) => {
   const gazePoints = JSON.parse(event.data);
   // gazePoints is an array of gaze data
   gazePoints.forEach(point => {
-    console.log(`Gaze: (${point.fixation_x}, ${point.fixation_y})`);
+    console.log(`Gaze: (${point.fixationX}, ${point.fixationY})`);
     // Use the gaze data in your application
   });
 };

--- a/tobii-service/app/models/__init__.py
+++ b/tobii-service/app/models/__init__.py
@@ -1,1 +1,3 @@
+from .gaze import DeviceInfo, GazePoint, StatusResponse, to_camel
 
+__all__ = ["DeviceInfo", "GazePoint", "StatusResponse", "to_camel"]

--- a/tobii-service/app/models/gaze.py
+++ b/tobii-service/app/models/gaze.py
@@ -1,19 +1,50 @@
+from typing import Optional
+
 from pydantic import BaseModel, ConfigDict, Field
+
+
+def to_camel(string: str) -> str:
+    """Convert snake_case to camelCase for JSON serialization."""
+    parts = string.split("_")
+    return parts[0] + "".join(word.capitalize() for word in parts[1:])
 
 
 class GazePoint(BaseModel):
     """Represents a single gaze point from the eye tracker."""
 
     model_config = ConfigDict(
+        populate_by_name=True,
+        alias_generator=to_camel,
         json_schema_extra={
             "example": {
-                "fixation_x": 0.5,
-                "fixation_y": 0.5,
+                "fixationX": 0.5,
+                "fixationY": 0.5,
                 "timestamp": 1234567890,
             }
-        }
+        },
     )
 
     fixation_x: float = Field(..., description="X coordinate (normalized 0-1)")
     fixation_y: float = Field(..., description="Y coordinate (normalized 0-1)")
     timestamp: int = Field(..., description="System timestamp in microseconds")
+
+
+class DeviceInfo(BaseModel):
+    """Tobii Pro device information."""
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        alias_generator=to_camel,
+    )
+
+    device_name: str
+    serial_number: str
+    model: str
+    firmware_version: str
+
+
+class StatusResponse(BaseModel):
+    """Response for the /status endpoint."""
+
+    connected: bool
+    device: Optional[DeviceInfo] = None

--- a/tobii-service/app/routers/tobii.py
+++ b/tobii-service/app/routers/tobii.py
@@ -1,9 +1,9 @@
 import asyncio
 import logging
-from typing import Any
 
 from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
 
+from app.models.gaze import StatusResponse
 from app.services.tobii_service import TobiiService
 
 logger = logging.getLogger(__name__)
@@ -12,12 +12,12 @@ router = APIRouter()
 tobii_service = TobiiService()
 
 
-@router.get("/status")
-async def get_status() -> dict[str, Any]:
+@router.get("/status", response_model=StatusResponse)
+async def get_status() -> StatusResponse:
     try:
         is_connected = tobii_service.is_connected()
         device_info = tobii_service.get_device_info() if is_connected else None
-        return {"connected": is_connected, "device": device_info}
+        return StatusResponse(connected=is_connected, device=device_info)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/tobii-service/app/services/tobii_service.py
+++ b/tobii-service/app/services/tobii_service.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import tobii_research as tr
 
-from app.models.gaze import GazePoint
+from app.models.gaze import DeviceInfo, GazePoint
 
 logger = logging.getLogger(__name__)
 
@@ -27,16 +27,16 @@ class TobiiService:
     def is_connected(self) -> bool:
         return self.eyetracker is not None
 
-    def get_device_info(self) -> dict[str, str] | None:
+    def get_device_info(self) -> DeviceInfo | None:
         if not self.eyetracker:
             return None
 
-        return {
-            "device_name": self.eyetracker.device_name,
-            "serial_number": self.eyetracker.serial_number,
-            "model": self.eyetracker.model,
-            "firmware_version": self.eyetracker.firmware_version,
-        }
+        return DeviceInfo(
+            device_name=self.eyetracker.device_name,
+            serial_number=self.eyetracker.serial_number,
+            model=self.eyetracker.model,
+            firmware_version=self.eyetracker.firmware_version,
+        )
 
     def _gaze_data_callback(self, gaze_data: dict[str, Any]) -> None:
         try:
@@ -97,7 +97,7 @@ class TobiiService:
         logger.info("Stopped gaze data capture")
 
     def get_gaze_data(self) -> list[dict[str, Any]]:
-        return [point.model_dump() for point in self.gaze_data]
+        return [point.model_dump(by_alias=True) for point in self.gaze_data]
 
     def clear_data(self) -> None:
         self.gaze_data.clear()


### PR DESCRIPTION
Closes #14

## Summary

Fixes the tobii-service API to use `camelCase` field names in all JSON responses, matching the project convention used by ml-service.

## Changes

### Models (`app/models/gaze.py`)
- Added `to_camel` utility function for `snake_case` → `camelCase` conversion
- Updated `GazePoint` model with `alias_generator=to_camel` and `populate_by_name=True`
- Created `DeviceInfo` model with camelCase aliases for device status fields
- Created `StatusResponse` model for typed `/status` endpoint responses
- Updated barrel exports in `__init__.py`

### Service (`app/services/tobii_service.py`)
- Changed `get_device_info()` to return `DeviceInfo` model instead of raw dict
- Updated `get_gaze_data()` to use `model_dump(by_alias=True)` for camelCase serialization

### Router (`app/routers/tobii.py`)
- Updated `/status` endpoint to use `StatusResponse` model with `response_model` annotation
- Removed unused `typing.Any` import

### Documentation
- Updated all JSON examples in API.md to use camelCase
- Updated all code examples (JS, TS, React) in API.md to use camelCase
- Updated README.md JSON examples and code snippets

## Fields Changed

| Before | After |
|---|---|
| `fixation_x` | `fixationX` |
| `fixation_y` | `fixationY` |
| `device_name` | `deviceName` |
| `serial_number` | `serialNumber` |
| `firmware_version` | `firmwareVersion` |