### PR TITLE
feat(web): privacy rewrite, pre-test education slides & OS download buttons

### DIFF
--- a/web/src/app/(marketing)/_components/download-section.tsx
+++ b/web/src/app/(marketing)/_components/download-section.tsx
@@ -8,8 +8,7 @@ import { cn } from '@/lib/utils';
 
 type Platform = 'windows' | 'macos' | 'linux' | 'unknown';
 
-const GITHUB_RELEASE_BASE =
-  'https://github.com/khalilelemam/eglex/releases/latest';
+const GITHUB_RELEASE_BASE = 'https://github.com/khalilelemam/eglex/releases/latest';
 
 interface PlatformInfo {
   label: string;
@@ -22,14 +21,14 @@ interface PlatformInfo {
 const PLATFORMS: Record<Exclude<Platform, 'unknown'>, PlatformInfo> = {
   windows: {
     label: 'Windows',
-    icon: <Monitor className="w-5 h-5" />,
+    icon: <Monitor className="h-5 w-5" />,
     assetKeyword: 'windows',
     extension: '.exe',
     available: true,
   },
   macos: {
     label: 'macOS',
-    icon: <Apple className="w-5 h-5" />,
+    icon: <Apple className="h-5 w-5" />,
     assetKeyword: 'macos',
     extension: '.dmg',
     available: false,
@@ -37,7 +36,12 @@ const PLATFORMS: Record<Exclude<Platform, 'unknown'>, PlatformInfo> = {
   linux: {
     label: 'Linux',
     icon: (
-      <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <svg
+        className="h-5 w-5"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        xmlns="http://www.w3.org/2000/svg"
+      >
         <path d="M12.504 0c-.155 0-.315.008-.48.021-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489a.424.424 0 00-.11.135c-.26.268-.45.6-.663.839-.199.199-.485.267-.797.4-.313.136-.658.269-.864.68-.09.189-.136.394-.132.602 0 .199.027.4.055.536.058.399.116.728.04.97-.249.68-.28 1.145-.106 1.484.174.334.535.47.94.601.81.2 1.91.135 2.774.6.926.466 1.866.67 2.616.47.526-.116.97-.464 1.208-.946.587-.003 1.23-.269 2.26-.334.699-.058 1.574.267 2.577.2.025.134.063.198.114.333l.003.003c.391.778 1.113 1.132 1.884 1.071.771-.06 1.592-.536 2.257-1.306.631-.765 1.683-1.084 2.378-1.503.348-.199.629-.469.649-.853.023-.4-.2-.811-.714-1.376v-.097l-.003-.003c-.17-.2-.25-.535-.338-.926-.085-.401-.182-.786-.492-1.046h-.003c-.059-.054-.123-.067-.188-.135a.357.357 0 00-.19-.064c.431-1.278.264-2.55-.173-3.694-.533-1.41-1.465-2.638-2.175-3.483-.796-1.005-1.576-1.957-1.56-3.368.026-2.152.236-6.133-3.544-6.139zm.529 3.405h.013c.213 0 .396.062.584.198.19.135.33.332.438.533.105.259.158.459.166.724 0-.02 0 0 0 0v.015a.503.503 0 01-.213.418.81.81 0 01-.472.15h-.005a.57.57 0 01-.514-.34c-.018-.04-.028-.053-.037-.116a1.35 1.35 0 01-.027-.263v-.015c0-.263.047-.51.145-.72.05-.107.123-.199.221-.271a.51.51 0 01.244-.08h.006zm-2.156.071c.095.004.183.04.272.093.089.07.155.146.226.27.039.067.069.146.088.217.035.134.061.266.061.404v.02a.39.39 0 01-.14.311.467.467 0 01-.362.14h-.005c-.166.003-.298-.076-.382-.216a.74.74 0 01-.084-.263.737.737 0 01-.01-.218c.003-.086.01-.181.04-.27a.68.68 0 01.152-.332.458.458 0 01.312-.15l.052-.005h-.02zm2.372 1.938c.157 0 .273.075.352.177.153.2.189.512.13.832-.062.31-.199.612-.418.808a.56.56 0 01-.327.126.386.386 0 01-.332-.203c-.09-.166-.121-.398-.062-.64.058-.237.197-.466.368-.599.065-.058.143-.1.217-.1h.002l.07-.001zm-2.82.094c.087-.002.167.04.231.088.18.146.303.398.34.645.035.249-.015.501-.145.662a.33.33 0 01-.259.146.317.317 0 01-.247-.124c-.13-.167-.188-.418-.168-.665.02-.252.098-.488.234-.639a.274.274 0 01.205-.114l.009.001z" />
       </svg>
     ),
@@ -71,22 +75,22 @@ export function DownloadSection() {
   const platformKeys = Object.keys(PLATFORMS) as Array<Exclude<Platform, 'unknown'>>;
 
   return (
-    <section id="download" className="py-20 px-6">
-      <div className="max-w-3xl mx-auto text-center">
+    <section id="download" className="px-6 py-20">
+      <div className="mx-auto max-w-3xl text-center">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
         >
-          <Download className="w-8 h-8 mx-auto mb-4 text-muted-foreground/60" />
-          <h2 className="text-3xl font-bold mb-3">Download Tobii Service</h2>
-          <p className="text-muted-foreground max-w-lg mx-auto mb-10">
-            To use Lexora with a Tobii eye tracker, download the desktop service for your
-            operating system. The service runs locally and streams gaze data to the web app.
+          <Download className="text-muted-foreground/60 mx-auto mb-4 h-8 w-8" />
+          <h2 className="mb-3 text-3xl font-bold">Download Tobii Service</h2>
+          <p className="text-muted-foreground mx-auto mb-10 max-w-lg">
+            To use Lexora with a Tobii eye tracker, download the desktop service for your operating
+            system. The service runs locally and streams gaze data to the web app.
           </p>
         </motion.div>
 
-        <div className="grid sm:grid-cols-3 gap-4 max-w-xl mx-auto">
+        <div className="mx-auto grid max-w-xl gap-4 sm:grid-cols-3">
           {platformKeys.map((key) => {
             const info = PLATFORMS[key];
             const isCurrent = key === currentPlatform;
@@ -100,26 +104,21 @@ export function DownloadSection() {
                 transition={{ delay: platformKeys.indexOf(key) * 0.1 }}
               >
                 {info.available ? (
-                  <a
-                    href={GITHUB_RELEASE_BASE}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
+                  <a href={GITHUB_RELEASE_BASE} target="_blank" rel="noopener noreferrer">
                     <Button
                       variant={isCurrent ? 'default' : 'outline'}
                       className={cn(
-                        'w-full h-auto py-5 flex flex-col items-center gap-2 transition-all',
+                        'flex h-auto w-full flex-col items-center gap-2 py-5 transition-all',
                         isCurrent &&
-                          'bg-[oklch(0.40_0.04_110)] hover:bg-[oklch(0.35_0.04_110)] text-[oklch(0.94_0.02_90)] shadow-md ring-2 ring-[oklch(0.70_0.10_115/0.3)]',
-                        !isCurrent &&
-                          'border-border/60 hover:bg-muted/50',
+                          'bg-[oklch(0.40_0.04_110)] text-[oklch(0.94_0.02_90)] shadow-md ring-2 ring-[oklch(0.70_0.10_115/0.3)] hover:bg-[oklch(0.35_0.04_110)]',
+                        !isCurrent && 'border-border/60 hover:bg-muted/50',
                       )}
                     >
                       {info.icon}
                       <span className="text-sm font-semibold">{info.label}</span>
                       <span className="text-[10px] opacity-60">{info.extension}</span>
                       {isCurrent && (
-                        <span className="text-[9px] font-medium opacity-80 uppercase tracking-wider">
+                        <span className="text-[9px] font-medium tracking-wider uppercase opacity-80">
                           Recommended
                         </span>
                       )}
@@ -129,7 +128,7 @@ export function DownloadSection() {
                   <Button
                     variant="outline"
                     disabled
-                    className="w-full h-auto py-5 flex flex-col items-center gap-2 opacity-50 cursor-not-allowed"
+                    className="flex h-auto w-full cursor-not-allowed flex-col items-center gap-2 py-5 opacity-50"
                   >
                     {info.icon}
                     <span className="text-sm font-semibold">{info.label}</span>
@@ -141,14 +140,14 @@ export function DownloadSection() {
           })}
         </div>
 
-        <p className="mt-6 text-xs text-muted-foreground/50">
+        <p className="text-muted-foreground/50 mt-6 text-xs">
           <a
             href={GITHUB_RELEASE_BASE}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 hover:text-muted-foreground transition-colors"
+            className="hover:text-muted-foreground inline-flex items-center gap-1 transition-colors"
           >
-            View all releases on GitHub <ExternalLink className="w-3 h-3" />
+            View all releases on GitHub <ExternalLink className="h-3 w-3" />
           </a>
         </p>
       </div>

--- a/web/src/app/(marketing)/_components/download-section.tsx
+++ b/web/src/app/(marketing)/_components/download-section.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { Download, Monitor, Apple, ExternalLink } from 'lucide-react';
+import { Download, Monitor, Apple } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
@@ -69,6 +69,8 @@ export function DownloadSection() {
   const [currentPlatform, setCurrentPlatform] = useState<Platform>('unknown');
 
   useEffect(() => {
+    // @ts-expect-error - necessary to avoid hydration mismatch
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setCurrentPlatform(detectPlatform());
   }, []);
 

--- a/web/src/app/(marketing)/_components/download-section.tsx
+++ b/web/src/app/(marketing)/_components/download-section.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import { Download, Monitor, Apple, ExternalLink } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type Platform = 'windows' | 'macos' | 'linux' | 'unknown';
+
+const GITHUB_RELEASE_BASE =
+  'https://github.com/khalilelemam/eglex/releases/latest';
+
+interface PlatformInfo {
+  label: string;
+  icon: React.ReactNode;
+  assetKeyword: string;
+  extension: string;
+  available: boolean;
+}
+
+const PLATFORMS: Record<Exclude<Platform, 'unknown'>, PlatformInfo> = {
+  windows: {
+    label: 'Windows',
+    icon: <Monitor className="w-5 h-5" />,
+    assetKeyword: 'windows',
+    extension: '.exe',
+    available: true,
+  },
+  macos: {
+    label: 'macOS',
+    icon: <Apple className="w-5 h-5" />,
+    assetKeyword: 'macos',
+    extension: '.dmg',
+    available: false,
+  },
+  linux: {
+    label: 'Linux',
+    icon: (
+      <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+        <path d="M12.504 0c-.155 0-.315.008-.48.021-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489a.424.424 0 00-.11.135c-.26.268-.45.6-.663.839-.199.199-.485.267-.797.4-.313.136-.658.269-.864.68-.09.189-.136.394-.132.602 0 .199.027.4.055.536.058.399.116.728.04.97-.249.68-.28 1.145-.106 1.484.174.334.535.47.94.601.81.2 1.91.135 2.774.6.926.466 1.866.67 2.616.47.526-.116.97-.464 1.208-.946.587-.003 1.23-.269 2.26-.334.699-.058 1.574.267 2.577.2.025.134.063.198.114.333l.003.003c.391.778 1.113 1.132 1.884 1.071.771-.06 1.592-.536 2.257-1.306.631-.765 1.683-1.084 2.378-1.503.348-.199.629-.469.649-.853.023-.4-.2-.811-.714-1.376v-.097l-.003-.003c-.17-.2-.25-.535-.338-.926-.085-.401-.182-.786-.492-1.046h-.003c-.059-.054-.123-.067-.188-.135a.357.357 0 00-.19-.064c.431-1.278.264-2.55-.173-3.694-.533-1.41-1.465-2.638-2.175-3.483-.796-1.005-1.576-1.957-1.56-3.368.026-2.152.236-6.133-3.544-6.139zm.529 3.405h.013c.213 0 .396.062.584.198.19.135.33.332.438.533.105.259.158.459.166.724 0-.02 0 0 0 0v.015a.503.503 0 01-.213.418.81.81 0 01-.472.15h-.005a.57.57 0 01-.514-.34c-.018-.04-.028-.053-.037-.116a1.35 1.35 0 01-.027-.263v-.015c0-.263.047-.51.145-.72.05-.107.123-.199.221-.271a.51.51 0 01.244-.08h.006zm-2.156.071c.095.004.183.04.272.093.089.07.155.146.226.27.039.067.069.146.088.217.035.134.061.266.061.404v.02a.39.39 0 01-.14.311.467.467 0 01-.362.14h-.005c-.166.003-.298-.076-.382-.216a.74.74 0 01-.084-.263.737.737 0 01-.01-.218c.003-.086.01-.181.04-.27a.68.68 0 01.152-.332.458.458 0 01.312-.15l.052-.005h-.02zm2.372 1.938c.157 0 .273.075.352.177.153.2.189.512.13.832-.062.31-.199.612-.418.808a.56.56 0 01-.327.126.386.386 0 01-.332-.203c-.09-.166-.121-.398-.062-.64.058-.237.197-.466.368-.599.065-.058.143-.1.217-.1h.002l.07-.001zm-2.82.094c.087-.002.167.04.231.088.18.146.303.398.34.645.035.249-.015.501-.145.662a.33.33 0 01-.259.146.317.317 0 01-.247-.124c-.13-.167-.188-.418-.168-.665.02-.252.098-.488.234-.639a.274.274 0 01.205-.114l.009.001z" />
+      </svg>
+    ),
+    assetKeyword: 'linux',
+    extension: '.AppImage',
+    available: false,
+  },
+};
+
+function detectPlatform(): Platform {
+  if (typeof navigator === 'undefined') return 'unknown';
+  const ua = navigator.userAgent.toLowerCase();
+  if (ua.includes('win')) return 'windows';
+  if (ua.includes('mac')) return 'macos';
+  if (ua.includes('linux')) return 'linux';
+  return 'unknown';
+}
+
+/**
+ * OS-specific download buttons section.
+ * Auto-detects the user's OS and highlights the matching button.
+ * Links to GitHub Releases latest assets.
+ */
+export function DownloadSection() {
+  const [currentPlatform, setCurrentPlatform] = useState<Platform>('unknown');
+
+  useEffect(() => {
+    setCurrentPlatform(detectPlatform());
+  }, []);
+
+  const platformKeys = Object.keys(PLATFORMS) as Array<Exclude<Platform, 'unknown'>>;
+
+  return (
+    <section id="download" className="py-20 px-6">
+      <div className="max-w-3xl mx-auto text-center">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+        >
+          <Download className="w-8 h-8 mx-auto mb-4 text-muted-foreground/60" />
+          <h2 className="text-3xl font-bold mb-3">Download Tobii Service</h2>
+          <p className="text-muted-foreground max-w-lg mx-auto mb-10">
+            To use Lexora with a Tobii eye tracker, download the desktop service for your
+            operating system. The service runs locally and streams gaze data to the web app.
+          </p>
+        </motion.div>
+
+        <div className="grid sm:grid-cols-3 gap-4 max-w-xl mx-auto">
+          {platformKeys.map((key) => {
+            const info = PLATFORMS[key];
+            const isCurrent = key === currentPlatform;
+
+            return (
+              <motion.div
+                key={key}
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ delay: platformKeys.indexOf(key) * 0.1 }}
+              >
+                {info.available ? (
+                  <a
+                    href={GITHUB_RELEASE_BASE}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Button
+                      variant={isCurrent ? 'default' : 'outline'}
+                      className={cn(
+                        'w-full h-auto py-5 flex flex-col items-center gap-2 transition-all',
+                        isCurrent &&
+                          'bg-[oklch(0.40_0.04_110)] hover:bg-[oklch(0.35_0.04_110)] text-[oklch(0.94_0.02_90)] shadow-md ring-2 ring-[oklch(0.70_0.10_115/0.3)]',
+                        !isCurrent &&
+                          'border-border/60 hover:bg-muted/50',
+                      )}
+                    >
+                      {info.icon}
+                      <span className="text-sm font-semibold">{info.label}</span>
+                      <span className="text-[10px] opacity-60">{info.extension}</span>
+                      {isCurrent && (
+                        <span className="text-[9px] font-medium opacity-80 uppercase tracking-wider">
+                          Recommended
+                        </span>
+                      )}
+                    </Button>
+                  </a>
+                ) : (
+                  <Button
+                    variant="outline"
+                    disabled
+                    className="w-full h-auto py-5 flex flex-col items-center gap-2 opacity-50 cursor-not-allowed"
+                  >
+                    {info.icon}
+                    <span className="text-sm font-semibold">{info.label}</span>
+                    <span className="text-[10px] opacity-60">Coming soon</span>
+                  </Button>
+                )}
+              </motion.div>
+            );
+          })}
+        </div>
+
+        <p className="mt-6 text-xs text-muted-foreground/50">
+          <a
+            href={GITHUB_RELEASE_BASE}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 hover:text-muted-foreground transition-colors"
+          >
+            View all releases on GitHub <ExternalLink className="w-3 h-3" />
+          </a>
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/web/src/app/(marketing)/_components/download-section.tsx
+++ b/web/src/app/(marketing)/_components/download-section.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/lib/utils';
 
 type Platform = 'windows' | 'macos' | 'linux' | 'unknown';
 
-const GITHUB_RELEASE_BASE = 'https://github.com/khalilelemam/eglex/releases/latest';
+const DOWNLOAD_BASE = '/api/download/service';
 
 interface PlatformInfo {
   label: string;
@@ -30,8 +30,8 @@ const PLATFORMS: Record<Exclude<Platform, 'unknown'>, PlatformInfo> = {
     label: 'macOS',
     icon: <Apple className="h-5 w-5" />,
     assetKeyword: 'macos',
-    extension: '.dmg',
-    available: false,
+    extension: '.pkg',
+    available: true,
   },
   linux: {
     label: 'Linux',
@@ -46,8 +46,8 @@ const PLATFORMS: Record<Exclude<Platform, 'unknown'>, PlatformInfo> = {
       </svg>
     ),
     assetKeyword: 'linux',
-    extension: '.AppImage',
-    available: false,
+    extension: '.deb',
+    available: true,
   },
 };
 
@@ -104,7 +104,7 @@ export function DownloadSection() {
                 transition={{ delay: platformKeys.indexOf(key) * 0.1 }}
               >
                 {info.available ? (
-                  <a href={GITHUB_RELEASE_BASE} target="_blank" rel="noopener noreferrer">
+                  <a href={`${DOWNLOAD_BASE}?platform=${key}`}>
                     <Button
                       variant={isCurrent ? 'default' : 'outline'}
                       className={cn(
@@ -141,14 +141,7 @@ export function DownloadSection() {
         </div>
 
         <p className="text-muted-foreground/50 mt-6 text-xs">
-          <a
-            href={GITHUB_RELEASE_BASE}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-muted-foreground inline-flex items-center gap-1 transition-colors"
-          >
-            View all releases on GitHub <ExternalLink className="h-3 w-3" />
-          </a>
+          The service runs locally on your machine and streams gaze data to the web app.
         </p>
       </div>
     </section>

--- a/web/src/app/(marketing)/page.tsx
+++ b/web/src/app/(marketing)/page.tsx
@@ -13,6 +13,7 @@ import { AnimatedStat } from './_components/animated-stat';
 import { FeatureCard } from './_components/feature-card';
 import { StepCard } from './_components/step-card';
 import { CtaSection } from './_components/cta-section';
+import { DownloadSection } from './_components/download-section';
 
 /**
  * Lexora landing page — Server Component.
@@ -140,6 +141,9 @@ export default function HomePage() {
           </div>
         </div>
       </section>
+
+      {/* ── Download Tobii Service ────────────────────────── */}
+      <DownloadSection />
 
       {/* ── Call to Action ────────────────────────────────── */}
       <CtaSection />

--- a/web/src/app/(marketing)/privacy/page.tsx
+++ b/web/src/app/(marketing)/privacy/page.tsx
@@ -1,87 +1,184 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Privacy',
+  title: 'Privacy Policy — Lexora',
   description:
-    'Lexora privacy policy — how we handle eye-tracking data, camera access, and your personal information.',
+    'How Lexora handles eye-tracking data, camera access, and personal information during dyslexia screening.',
 };
 
 export default function PrivacyPage() {
   return (
     <main className="min-h-screen bg-background pt-24 pb-16">
       <div className="max-w-3xl mx-auto px-6">
-        <h1 className="text-4xl font-bold mb-4">Privacy Policy</h1>
-        <p className="text-muted-foreground mb-10">
-          Your privacy is fundamental to Lexora. This page explains exactly what data
-          we access, how we process it, and what happens to it afterwards.
+        <h1 className="text-4xl font-bold mb-2">Privacy Policy</h1>
+        <p className="text-sm text-muted-foreground mb-10">
+          Last updated: April 2026
         </p>
 
         <div className="space-y-10">
-          <Section title="Camera Access">
+          <Section title="1. Data Controller">
             <p>
-              When using webcam-based tracking, Lexora requests access to your camera.
+              Lexora is a research tool developed at the Faculty of Computing and Data Science.
+              For questions about data handling, contact us via the project&apos;s{' '}
+              <a
+                href="https://github.com/khalilelemam/eglex"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary underline underline-offset-4 hover:text-primary/80 transition-colors"
+              >
+                GitHub repository
+              </a>.
+            </p>
+          </Section>
+
+          <Section title="2. Legal Basis for Processing">
+            <p>
+              We process limited gaze coordinate data under the legal basis of <strong>legitimate
+              research interest</strong> (GDPR Article 6(1)(f)). This processing is necessary
+              for conducting non-invasive dyslexia screening research. No personal data beyond
+              abstract gaze coordinates is collected or processed.
+            </p>
+          </Section>
+
+          <Section title="3. Camera Access &amp; Video Processing">
+            <p>
+              When using webcam-based tracking, Lexora requests access to your device&apos;s camera.
               The video feed is processed <strong>entirely in your browser</strong> using
-              MediaPipe FaceLandmarker. No video frames are ever transmitted to any server,
-              recorded, or stored. The camera feed is used solely to extract iris position
-              coordinates in real-time.
+              Google&apos;s MediaPipe FaceLandmarker (loaded as a WebAssembly module). Critical details:
             </p>
-          </Section>
-
-          <Section title="Gaze Data">
-            <p>
-              During the screening test, Lexora collects normalized gaze coordinates
-              (x, y values between 0 and 1) timestamped to each reading task. This data is:
-            </p>
-            <ul className="list-disc list-inside mt-2 space-y-1">
-              <li>Processed locally in your browser to extract reading features</li>
-              <li>Sent to our ML service only for classification (risk assessment)</li>
-              <li>Not stored persistently on any server after the session ends</li>
-              <li>Abstract and anonymized — no personal identifiers are attached</li>
+            <ul className="list-disc list-inside mt-3 space-y-1.5">
+              <li>No video frames are transmitted to any server</li>
+              <li>No video is recorded, stored, or cached</li>
+              <li>No screenshots or images of the user are captured</li>
+              <li>Only abstract iris position coordinates (numerical x, y values) are extracted</li>
+              <li>Camera access ends immediately when you leave the test page</li>
             </ul>
           </Section>
 
-          <Section title="Tobii Eye Tracker">
+          <Section title="4. Data Categories Collected">
             <p>
-              When using a Tobii eye tracker, gaze data is streamed from the local
-              Tobii desktop service (<code className="text-xs bg-muted px-1 py-0.5 rounded">localhost:28980</code>)
-              directly to the web application. This communication stays entirely on your
-              local machine — no data leaves your computer during tracking.
+              During a screening session, Lexora collects <strong>only</strong> the following:
+            </p>
+            <ul className="list-disc list-inside mt-3 space-y-1.5">
+              <li>
+                <strong>Gaze coordinates</strong> — normalized x, y values (0 to 1) representing
+                where on the screen the user was looking, sampled at the device&apos;s refresh rate
+              </li>
+              <li>
+                <strong>Timestamps</strong> — millisecond-precision timing for each gaze sample
+              </li>
+              <li>
+                <strong>Screen dimensions</strong> — width and height of the display (for coordinate normalization)
+              </li>
+            </ul>
+            <p className="mt-3">
+              This data is abstract, anonymized, and contains <strong>no personally
+              identifiable information</strong>.
             </p>
           </Section>
 
-          <Section title="What We Don&apos;t Collect">
-            <ul className="list-disc list-inside space-y-1">
-              <li>No names, emails, or personal identifiers</li>
-              <li>No video recordings or camera snapshots</li>
-              <li>No browsing history or device fingerprints</li>
-              <li>No cookies for tracking or advertising</li>
-              <li>No analytics or third-party tracking scripts</li>
+          <Section title="5. Data Retention &amp; Storage">
+            <p>
+              Lexora operates on a <strong>session-only</strong> data model:
+            </p>
+            <ul className="list-disc list-inside mt-3 space-y-1.5">
+              <li>Gaze data exists only in browser memory during the active session</li>
+              <li>Data is sent to the ML classification endpoint for real-time analysis</li>
+              <li>No gaze data is stored persistently on any server</li>
+              <li>No databases, logs, or files retain user data after the session ends</li>
+              <li>Closing the browser tab permanently destroys all session data</li>
             </ul>
           </Section>
 
-          <Section title="Local Processing">
+          <Section title="6. Tobii Eye Tracker">
             <p>
-              The calibration process (polynomial ridge regression model fitting),
-              gaze feature extraction, and all data visualizations happen entirely
-              in your browser using JavaScript. The only external communication is
-              the final feature vector sent to the ML classification endpoint.
+              When using a Tobii eye tracker, gaze data is streamed from the local Tobii desktop
+              service (<code className="text-xs bg-muted px-1.5 py-0.5 rounded">localhost:28980</code>)
+              directly to the web application via WebSocket. This communication is entirely
+              local — <strong>no data leaves your computer</strong> during tracking. The Tobii
+              service runs as a local process and does not communicate with external servers.
             </p>
           </Section>
 
-          <Section title="Research Use">
+          <Section title="7. Third-Party Services">
             <p>
-              Lexora is a research tool developed at the Faculty of Computing and
-              Data Science. It is intended for screening purposes only and does not
-              store or process personal health information. If you participate in a
-              formal research study using Lexora, separate consent and data handling
-              procedures will apply as governed by the research ethics board.
+              Lexora uses the following third-party resources:
+            </p>
+            <ul className="list-disc list-inside mt-3 space-y-1.5">
+              <li>
+                <strong>MediaPipe FaceLandmarker</strong> — Google&apos;s face mesh model, loaded as
+                a WebAssembly module from CDN. The model runs locally in your browser; no data
+                is sent to Google.
+              </li>
+              <li>
+                <strong>Lexora ML Service</strong> — Our classification endpoint receives only
+                abstract gaze feature vectors (fixation durations, saccade amplitudes) for
+                risk assessment. No personal identifiers are attached.
+              </li>
+            </ul>
+          </Section>
+
+          <Section title="8. What We Do NOT Collect">
+            <ul className="list-disc list-inside space-y-1.5">
+              <li>No names, emails, phone numbers, or personal identifiers</li>
+              <li>No video recordings, camera snapshots, or face images</li>
+              <li>No browsing history, device fingerprints, or IP addresses</li>
+              <li>No cookies for tracking or advertising purposes</li>
+              <li>No analytics scripts, ad trackers, or third-party tracking</li>
+              <li>No health records or medical data</li>
+            </ul>
+          </Section>
+
+          <Section title="9. Children&apos;s Privacy">
+            <p>
+              Lexora is designed as a dyslexia screening tool that may be used with children.
+              We take children&apos;s privacy especially seriously:
+            </p>
+            <ul className="list-disc list-inside mt-3 space-y-1.5">
+              <li>No personal information about the child is collected or stored</li>
+              <li>Camera feed is processed locally and never transmitted</li>
+              <li>We recommend that a parent, guardian, or educator supervises any session involving a child</li>
+              <li>Results are displayed immediately and not stored — the supervising adult should note them if needed</li>
+            </ul>
+          </Section>
+
+          <Section title="10. Data Subject Rights">
+            <p>
+              Under applicable data protection regulations (including GDPR), you have the right to:
+            </p>
+            <ul className="list-disc list-inside mt-3 space-y-1.5">
+              <li><strong>Access</strong> — request what data we hold (none is persisted)</li>
+              <li><strong>Erasure</strong> — request deletion (data is automatically deleted after each session)</li>
+              <li><strong>Objection</strong> — you can stop the test at any time by closing the browser</li>
+              <li><strong>Portability</strong> — gaze data can be exported during the session if needed</li>
+            </ul>
+            <p className="mt-3">
+              Since Lexora does not store any personal data beyond the active session, most
+              of these rights are inherently satisfied by design.
             </p>
           </Section>
 
-          <Section title="Contact">
+          <Section title="11. Research Use">
             <p>
-              If you have questions about how Lexora handles your data, please reach
-              out via the project&apos;s{' '}
+              This tool is intended for <strong>research and screening purposes only</strong> and
+              does not constitute a medical diagnosis. If you participate in a formal research
+              study using Lexora, separate informed consent and data handling procedures will
+              apply as governed by the relevant research ethics board.
+            </p>
+          </Section>
+
+          <Section title="12. Changes to This Policy">
+            <p>
+              We may update this privacy policy from time to time. Changes will be reflected
+              on this page with an updated &quot;Last updated&quot; date. Continued use of Lexora
+              after changes constitutes acceptance of the revised policy.
+            </p>
+          </Section>
+
+          <Section title="13. Contact">
+            <p>
+              If you have questions about how Lexora handles your data, please reach out via
+              the project&apos;s{' '}
               <a
                 href="https://github.com/khalilelemam/eglex"
                 target="_blank"

--- a/web/src/app/(marketing)/privacy/page.tsx
+++ b/web/src/app/(marketing)/privacy/page.tsx
@@ -8,35 +8,34 @@ export const metadata: Metadata = {
 
 export default function PrivacyPage() {
   return (
-    <main className="min-h-screen bg-background pt-24 pb-16">
-      <div className="max-w-3xl mx-auto px-6">
-        <h1 className="text-4xl font-bold mb-2">Privacy Policy</h1>
-        <p className="text-sm text-muted-foreground mb-10">
-          Last updated: April 2026
-        </p>
+    <main className="bg-background min-h-screen pt-24 pb-16">
+      <div className="mx-auto max-w-3xl px-6">
+        <h1 className="mb-2 text-4xl font-bold">Privacy Policy</h1>
+        <p className="text-muted-foreground mb-10 text-sm">Last updated: April 2026</p>
 
         <div className="space-y-10">
           <Section title="1. Data Controller">
             <p>
-              Lexora is a research tool developed at the Faculty of Computing and Data Science.
-              For questions about data handling, contact us via the project&apos;s{' '}
+              Lexora is a research tool developed at the Faculty of Computing and Data Science. For
+              questions about data handling, contact us via the project&apos;s{' '}
               <a
                 href="https://github.com/khalilelemam/eglex"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-primary underline underline-offset-4 hover:text-primary/80 transition-colors"
+                className="text-primary hover:text-primary/80 underline underline-offset-4 transition-colors"
               >
                 GitHub repository
-              </a>.
+              </a>
+              .
             </p>
           </Section>
 
           <Section title="2. Legal Basis for Processing">
             <p>
-              We process limited gaze coordinate data under the legal basis of <strong>legitimate
-              research interest</strong> (GDPR Article 6(1)(f)). This processing is necessary
-              for conducting non-invasive dyslexia screening research. No personal data beyond
-              abstract gaze coordinates is collected or processed.
+              We process limited gaze coordinate data under the legal basis of{' '}
+              <strong>legitimate research interest</strong> (GDPR Article 6(1)(f)). This processing
+              is necessary for conducting non-invasive dyslexia screening research. No personal data
+              beyond abstract gaze coordinates is collected or processed.
             </p>
           </Section>
 
@@ -44,9 +43,10 @@ export default function PrivacyPage() {
             <p>
               When using webcam-based tracking, Lexora requests access to your device&apos;s camera.
               The video feed is processed <strong>entirely in your browser</strong> using
-              Google&apos;s MediaPipe FaceLandmarker (loaded as a WebAssembly module). Critical details:
+              Google&apos;s MediaPipe FaceLandmarker (loaded as a WebAssembly module). Critical
+              details:
             </p>
-            <ul className="list-disc list-inside mt-3 space-y-1.5">
+            <ul className="mt-3 list-inside list-disc space-y-1.5">
               <li>No video frames are transmitted to any server</li>
               <li>No video is recorded, stored, or cached</li>
               <li>No screenshots or images of the user are captured</li>
@@ -59,7 +59,7 @@ export default function PrivacyPage() {
             <p>
               During a screening session, Lexora collects <strong>only</strong> the following:
             </p>
-            <ul className="list-disc list-inside mt-3 space-y-1.5">
+            <ul className="mt-3 list-inside list-disc space-y-1.5">
               <li>
                 <strong>Gaze coordinates</strong> — normalized x, y values (0 to 1) representing
                 where on the screen the user was looking, sampled at the device&apos;s refresh rate
@@ -68,12 +68,13 @@ export default function PrivacyPage() {
                 <strong>Timestamps</strong> — millisecond-precision timing for each gaze sample
               </li>
               <li>
-                <strong>Screen dimensions</strong> — width and height of the display (for coordinate normalization)
+                <strong>Screen dimensions</strong> — width and height of the display (for coordinate
+                normalization)
               </li>
             </ul>
             <p className="mt-3">
-              This data is abstract, anonymized, and contains <strong>no personally
-              identifiable information</strong>.
+              This data is abstract, anonymized, and contains{' '}
+              <strong>no personally identifiable information</strong>.
             </p>
           </Section>
 
@@ -81,7 +82,7 @@ export default function PrivacyPage() {
             <p>
               Lexora operates on a <strong>session-only</strong> data model:
             </p>
-            <ul className="list-disc list-inside mt-3 space-y-1.5">
+            <ul className="mt-3 list-inside list-disc space-y-1.5">
               <li>Gaze data exists only in browser memory during the active session</li>
               <li>Data is sent to the ML classification endpoint for real-time analysis</li>
               <li>No gaze data is stored persistently on any server</li>
@@ -93,33 +94,32 @@ export default function PrivacyPage() {
           <Section title="6. Tobii Eye Tracker">
             <p>
               When using a Tobii eye tracker, gaze data is streamed from the local Tobii desktop
-              service (<code className="text-xs bg-muted px-1.5 py-0.5 rounded">localhost:28980</code>)
-              directly to the web application via WebSocket. This communication is entirely
-              local — <strong>no data leaves your computer</strong> during tracking. The Tobii
-              service runs as a local process and does not communicate with external servers.
+              service (
+              <code className="bg-muted rounded px-1.5 py-0.5 text-xs">localhost:28980</code>)
+              directly to the web application via WebSocket. This communication is entirely local —{' '}
+              <strong>no data leaves your computer</strong> during tracking. The Tobii service runs
+              as a local process and does not communicate with external servers.
             </p>
           </Section>
 
           <Section title="7. Third-Party Services">
-            <p>
-              Lexora uses the following third-party resources:
-            </p>
-            <ul className="list-disc list-inside mt-3 space-y-1.5">
+            <p>Lexora uses the following third-party resources:</p>
+            <ul className="mt-3 list-inside list-disc space-y-1.5">
               <li>
                 <strong>MediaPipe FaceLandmarker</strong> — Google&apos;s face mesh model, loaded as
-                a WebAssembly module from CDN. The model runs locally in your browser; no data
-                is sent to Google.
+                a WebAssembly module from CDN. The model runs locally in your browser; no data is
+                sent to Google.
               </li>
               <li>
                 <strong>Lexora ML Service</strong> — Our classification endpoint receives only
-                abstract gaze feature vectors (fixation durations, saccade amplitudes) for
-                risk assessment. No personal identifiers are attached.
+                abstract gaze feature vectors (fixation durations, saccade amplitudes) for risk
+                assessment. No personal identifiers are attached.
               </li>
             </ul>
           </Section>
 
           <Section title="8. What We Do NOT Collect">
-            <ul className="list-disc list-inside space-y-1.5">
+            <ul className="list-inside list-disc space-y-1.5">
               <li>No names, emails, phone numbers, or personal identifiers</li>
               <li>No video recordings, camera snapshots, or face images</li>
               <li>No browsing history, device fingerprints, or IP addresses</li>
@@ -129,16 +129,22 @@ export default function PrivacyPage() {
             </ul>
           </Section>
 
-          <Section title="9. Children&apos;s Privacy">
+          <Section title="9. Children's Privacy">
             <p>
-              Lexora is designed as a dyslexia screening tool that may be used with children.
-              We take children&apos;s privacy especially seriously:
+              Lexora is designed as a dyslexia screening tool that may be used with children. We
+              take children&apos;s privacy especially seriously:
             </p>
-            <ul className="list-disc list-inside mt-3 space-y-1.5">
+            <ul className="mt-3 list-inside list-disc space-y-1.5">
               <li>No personal information about the child is collected or stored</li>
               <li>Camera feed is processed locally and never transmitted</li>
-              <li>We recommend that a parent, guardian, or educator supervises any session involving a child</li>
-              <li>Results are displayed immediately and not stored — the supervising adult should note them if needed</li>
+              <li>
+                We recommend that a parent, guardian, or educator supervises any session involving a
+                child
+              </li>
+              <li>
+                Results are displayed immediately and not stored — the supervising adult should note
+                them if needed
+              </li>
             </ul>
           </Section>
 
@@ -146,47 +152,59 @@ export default function PrivacyPage() {
             <p>
               Under applicable data protection regulations (including GDPR), you have the right to:
             </p>
-            <ul className="list-disc list-inside mt-3 space-y-1.5">
-              <li><strong>Access</strong> — request what data we hold (none is persisted)</li>
-              <li><strong>Erasure</strong> — request deletion (data is automatically deleted after each session)</li>
-              <li><strong>Objection</strong> — you can stop the test at any time by closing the browser</li>
-              <li><strong>Portability</strong> — gaze data can be exported during the session if needed</li>
+            <ul className="mt-3 list-inside list-disc space-y-1.5">
+              <li>
+                <strong>Access</strong> — request what data we hold (none is persisted)
+              </li>
+              <li>
+                <strong>Erasure</strong> — request deletion (data is automatically deleted after
+                each session)
+              </li>
+              <li>
+                <strong>Objection</strong> — you can stop the test at any time by closing the
+                browser
+              </li>
+              <li>
+                <strong>Portability</strong> — gaze data can be exported during the session if
+                needed
+              </li>
             </ul>
             <p className="mt-3">
-              Since Lexora does not store any personal data beyond the active session, most
-              of these rights are inherently satisfied by design.
+              Since Lexora does not store any personal data beyond the active session, most of these
+              rights are inherently satisfied by design.
             </p>
           </Section>
 
           <Section title="11. Research Use">
             <p>
               This tool is intended for <strong>research and screening purposes only</strong> and
-              does not constitute a medical diagnosis. If you participate in a formal research
-              study using Lexora, separate informed consent and data handling procedures will
-              apply as governed by the relevant research ethics board.
+              does not constitute a medical diagnosis. If you participate in a formal research study
+              using Lexora, separate informed consent and data handling procedures will apply as
+              governed by the relevant research ethics board.
             </p>
           </Section>
 
           <Section title="12. Changes to This Policy">
             <p>
-              We may update this privacy policy from time to time. Changes will be reflected
-              on this page with an updated &quot;Last updated&quot; date. Continued use of Lexora
-              after changes constitutes acceptance of the revised policy.
+              We may update this privacy policy from time to time. Changes will be reflected on this
+              page with an updated &quot;Last updated&quot; date. Continued use of Lexora after
+              changes constitutes acceptance of the revised policy.
             </p>
           </Section>
 
           <Section title="13. Contact">
             <p>
-              If you have questions about how Lexora handles your data, please reach out via
-              the project&apos;s{' '}
+              If you have questions about how Lexora handles your data, please reach out via the
+              project&apos;s{' '}
               <a
                 href="https://github.com/khalilelemam/eglex"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-primary underline underline-offset-4 hover:text-primary/80 transition-colors"
+                className="text-primary hover:text-primary/80 underline underline-offset-4 transition-colors"
               >
                 GitHub repository
-              </a>.
+              </a>
+              .
             </p>
           </Section>
         </div>
@@ -198,8 +216,8 @@ export default function PrivacyPage() {
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <section>
-      <h2 className="text-xl font-semibold mb-3">{title}</h2>
-      <div className="text-muted-foreground leading-relaxed space-y-2">{children}</div>
+      <h2 className="mb-3 text-xl font-semibold">{title}</h2>
+      <div className="text-muted-foreground space-y-2 leading-relaxed">{children}</div>
     </section>
   );
 }

--- a/web/src/app/api/download/service/route.ts
+++ b/web/src/app/api/download/service/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * GET /api/download/service?platform=windows|macos|linux
+ *
+ * Proxies the latest Lexora Tobii Service installer from GitHub Releases.
+ * Works even when the repo is private by using a server-side GitHub token.
+ */
+
+const GITHUB_OWNER = 'khalilelemam';
+const GITHUB_REPO = 'eglex';
+const RELEASES_API = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest`;
+
+// Platform keywords that match our asset naming convention
+const PLATFORM_MAP: Record<string, string> = {
+  windows: 'Lexora-Setup.exe',
+  macos: 'Lexora-macOS-Installer.pkg',
+  linux: 'Lexora-Linux-Installer.deb',
+};
+
+function detectPlatform(ua: string): string {
+  const lower = ua.toLowerCase();
+  if (lower.includes('mac') || lower.includes('darwin')) return 'macos';
+  if (lower.includes('linux')) return 'linux';
+  return 'windows'; // default
+}
+
+export async function GET(req: NextRequest) {
+  const token = process.env.GITHUB_TOKEN;
+
+  if (!token) {
+    return NextResponse.json(
+      { error: 'Server misconfiguration: missing GITHUB_TOKEN' },
+      { status: 500 },
+    );
+  }
+
+  // Determine platform from query param or User-Agent
+  const platform =
+    req.nextUrl.searchParams.get('platform') ??
+    detectPlatform(req.headers.get('user-agent') ?? '');
+
+  const expectedAsset = PLATFORM_MAP[platform];
+  if (!expectedAsset) {
+    return NextResponse.json(
+      { error: `Unsupported platform: ${platform}` },
+      { status: 400 },
+    );
+  }
+
+  try {
+    // Fetch latest release metadata
+    const releaseRes = await fetch(RELEASES_API, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github.v3+json',
+        'User-Agent': 'Lexora-Web-Downloader',
+      },
+      next: { revalidate: 300 }, // cache for 5 minutes
+    });
+
+    if (!releaseRes.ok) {
+      return NextResponse.json(
+        { error: 'Failed to fetch release info from GitHub' },
+        { status: releaseRes.status },
+      );
+    }
+
+    const release = await releaseRes.json();
+
+    // Find the matching asset
+    const asset = release.assets?.find(
+      (a: { name: string }) => a.name === expectedAsset,
+    );
+
+    if (!asset) {
+      return NextResponse.json(
+        { error: `No ${platform} installer found in latest release (${release.tag_name})` },
+        { status: 404 },
+      );
+    }
+
+    // Stream the binary from GitHub's API (works for private repos)
+    const assetRes = await fetch(asset.url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/octet-stream',
+        'User-Agent': 'Lexora-Web-Downloader',
+      },
+    });
+
+    if (!assetRes.ok || !assetRes.body) {
+      return NextResponse.json(
+        { error: 'Failed to download asset from GitHub' },
+        { status: 502 },
+      );
+    }
+
+    // Stream it back to the user as a file download
+    return new NextResponse(assetRes.body, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Content-Disposition': `attachment; filename="${expectedAsset}"`,
+        ...(assetRes.headers.get('content-length')
+          ? { 'Content-Length': assetRes.headers.get('content-length')! }
+          : {}),
+      },
+    });
+  } catch (err) {
+    console.error('Download proxy error:', err);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/download/service/route.ts
+++ b/web/src/app/api/download/service/route.ts
@@ -37,15 +37,11 @@ export async function GET(req: NextRequest) {
 
   // Determine platform from query param or User-Agent
   const platform =
-    req.nextUrl.searchParams.get('platform') ??
-    detectPlatform(req.headers.get('user-agent') ?? '');
+    req.nextUrl.searchParams.get('platform') ?? detectPlatform(req.headers.get('user-agent') ?? '');
 
   const expectedAsset = PLATFORM_MAP[platform];
   if (!expectedAsset) {
-    return NextResponse.json(
-      { error: `Unsupported platform: ${platform}` },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: `Unsupported platform: ${platform}` }, { status: 400 });
   }
 
   try {
@@ -69,9 +65,7 @@ export async function GET(req: NextRequest) {
     const release = await releaseRes.json();
 
     // Find the matching asset
-    const asset = release.assets?.find(
-      (a: { name: string }) => a.name === expectedAsset,
-    );
+    const asset = release.assets?.find((a: { name: string }) => a.name === expectedAsset);
 
     if (!asset) {
       return NextResponse.json(
@@ -90,10 +84,7 @@ export async function GET(req: NextRequest) {
     });
 
     if (!assetRes.ok || !assetRes.body) {
-      return NextResponse.json(
-        { error: 'Failed to download asset from GitHub' },
-        { status: 502 },
-      );
+      return NextResponse.json({ error: 'Failed to download asset from GitHub' }, { status: 502 });
     }
 
     // Stream it back to the user as a file download
@@ -109,9 +100,6 @@ export async function GET(req: NextRequest) {
     });
   } catch (err) {
     console.error('Download proxy error:', err);
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/web/src/app/test/tobii/page.tsx
+++ b/web/src/app/test/tobii/page.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/features/test/components';
 import { PreTestSlides } from '@/features/test/components/pre-test-slides';
 import { CalibrationSetup } from '@/features/test/components/calibration/calibration-setup';
+import { SupportedHardware } from '@/features/test/components/supported-hardware';
 import { useTestFlow, useTobiiGazeStream, useTobiiStatus } from '@/features/test/hooks';
 import { Star, Target } from 'lucide-react';
 import { useTobiiTaskBuffers } from '@/features/test/hooks/use-tobii-task-buffers';
@@ -212,8 +213,8 @@ export default function TobiiTestPage() {
               reading tasks: syllables, pseudo-words, and meaningful text.
             </p>
 
-            {/* Service Status & Supported Devices */}
-            <div className="grid w-full gap-6 md:grid-cols-[1fr_auto]">
+            {/* Service Status */}
+            <div className="mx-auto w-full max-w-2xl">
               <div className="border-border bg-background rounded-3xl border p-6 shadow-sm">
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                   <div>
@@ -274,19 +275,6 @@ export default function TobiiTestPage() {
                   </button>
                 </div>
               </div>
-
-              <div className="border-border bg-background rounded-3xl border p-6 shadow-sm">
-                <p className="text-sm font-semibold">Supported Tobii Devices</p>
-                <p className="text-muted-foreground mb-3 text-xs">
-                  Lexora supports Tobii Pro devices with SDK support. Consumer trackers such as
-                  Tobii Eye Tracker 5 are not compatible.
-                </p>
-                <ul className="text-muted-foreground list-disc space-y-2 pl-4 text-sm">
-                  <li>Tobii Pro Fusion</li>
-                  <li>Tobii Pro Spectrum</li>
-                  <li>Tobii Pro Nano</li>
-                </ul>
-              </div>
             </div>
 
             {/* Calibration Mode Selection */}
@@ -298,6 +286,9 @@ export default function TobiiTestPage() {
             />
           </div>
         );
+
+      case 'hardware-check':
+        return <SupportedHardware onContinue={() => dispatch({ type: 'HARDWARE_CONFIRMED' })} />;
 
       case 'pre-test-education':
         return (

--- a/web/src/app/test/tobii/page.tsx
+++ b/web/src/app/test/tobii/page.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/features/test/components';
 import { PreTestSlides } from '@/features/test/components/pre-test-slides';
 import { CalibrationSetup } from '@/features/test/components/calibration/calibration-setup';
-import { useTestFlow, useTobiiGazeStream } from '@/features/test/hooks';
+import { useTestFlow, useTobiiGazeStream, useTobiiStatus } from '@/features/test/hooks';
 import { Star, Target } from 'lucide-react';
 import { useTobiiTaskBuffers } from '@/features/test/hooks/use-tobii-task-buffers';
 import { submitTobiiTest } from '@/features/test/actions/submit-test';
@@ -32,6 +32,21 @@ export default function TobiiTestPage() {
   const router = useRouter();
   const { state, dispatch } = useTestFlow({ mode: 'tobii' });
   const tobiiState = state as TobiiTestFlowState;
+  const { status: tobiiStatus, checking: serviceChecking, error: serviceError, checkStatus } = useTobiiStatus();
+
+  const TOBII_SERVICE_URL = process.env.NEXT_PUBLIC_TOBII_SERVICE_URL ?? 'http://localhost:28980';
+  const serviceRunning = tobiiStatus?.connected === true;
+  const serviceDevice = tobiiStatus?.device;
+
+  const openTobiiService = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    const url = serviceRunning ? TOBII_SERVICE_URL : 'https://github.com/khalilelemam/eglex/releases/latest';
+    window.open(url, '_blank');
+  }, [serviceRunning, TOBII_SERVICE_URL]);
+
+  useEffect(() => {
+    checkStatus();
+  }, [checkStatus]);
 
   const calibrationParams = useMemo(() => {
     if (typeof window === 'undefined') {
@@ -181,12 +196,91 @@ export default function TobiiTestPage() {
     switch (tobiiState.currentState) {
       case 'idle':
         return (
-          <CalibrationSetup
-            resolvedMode={requestedCalibrationMode}
-            onSelectMode={setSelectedMode}
-            onStart={() => dispatch({ type: 'START' })}
-            startButtonText="Continue to Instructions"
-          />
+          <div className="flex flex-col items-center gap-6 w-full max-w-4xl mx-auto">
+            <h1 className="text-3xl font-bold">Eye Tracker Test</h1>
+            <p className="text-muted-foreground max-w-2xl text-center">
+              This test uses a Tobii eye tracker to screen for dyslexia indicators. It consists of 3
+              reading tasks: syllables, pseudo-words, and meaningful text.
+            </p>
+
+            {/* Service Status & Supported Devices */}
+            <div className="grid w-full gap-6 md:grid-cols-[1fr_auto]">
+              <div className="rounded-3xl border border-border bg-background p-6 shadow-sm">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-sm font-semibold">Tobii Service Status</p>
+                    <p className="text-muted-foreground text-xs">
+                      Lexora checks the local Tobii helper service on <code>localhost:28980</code>.
+                    </p>
+                  </div>
+                  <span
+                    className={`inline-flex rounded-full px-3 py-1 text-[11px] font-semibold ${
+                      serviceChecking
+                        ? 'bg-slate-200 text-slate-700'
+                        : serviceRunning
+                        ? 'bg-emerald-100 text-emerald-800'
+                        : 'bg-amber-100 text-amber-800'
+                    }`}
+                  >
+                    {serviceChecking ? 'Checking…' : serviceRunning ? 'Running' : 'Not running'}
+                  </span>
+                </div>
+                {serviceRunning ? (
+                  <div className="mt-4 space-y-2 rounded-2xl border border-emerald-100 bg-emerald-50 p-4 text-sm">
+                    <p className="font-medium text-foreground">Connected to the Tobii helper app.</p>
+                    <p className="text-muted-foreground">
+                      {serviceDevice?.deviceName ?? 'Tobii Pro device'} ({serviceDevice?.model ?? 'Unknown model'})
+                    </p>
+                    <p className="text-muted-foreground text-xs">Serial: {serviceDevice?.serialNumber ?? 'N/A'}</p>
+                  </div>
+                ) : (
+                  <div className="mt-4 space-y-2 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm">
+                    <p className="font-medium text-foreground">Tobii helper is not reachable.</p>
+                    <p className="text-muted-foreground">
+                      Install or start the Lexora Tobii Service app on your computer before running the Tobii test.
+                    </p>
+                    {serviceError && <p className="text-xs text-amber-700">{serviceError}</p>}
+                  </div>
+                )}
+                <div className="mt-4 flex flex-wrap gap-3">
+                  <button
+                    type="button"
+                    onClick={openTobiiService}
+                    className="bg-primary hover:bg-primary/90 text-primary-foreground rounded-md px-5 py-2 text-sm font-medium"
+                  >
+                    {serviceRunning ? 'Open Tobii Service' : 'Download Tobii Service'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={checkStatus}
+                    className="inline-flex items-center justify-center rounded-md border border-border bg-background px-5 py-2 text-sm font-medium text-foreground hover:bg-muted/70"
+                  >
+                    Refresh Status
+                  </button>
+                </div>
+              </div>
+
+              <div className="rounded-3xl border border-border bg-background p-6 shadow-sm">
+                <p className="text-sm font-semibold">Supported Tobii Devices</p>
+                <p className="text-muted-foreground text-xs mb-3">
+                  Lexora supports Tobii Pro devices with SDK support. Consumer trackers such as Tobii Eye Tracker 5 are not compatible.
+                </p>
+                <ul className="list-disc space-y-2 pl-4 text-sm text-muted-foreground">
+                  <li>Tobii Pro Fusion</li>
+                  <li>Tobii Pro Spectrum</li>
+                  <li>Tobii Pro Nano</li>
+                </ul>
+              </div>
+            </div>
+
+            {/* Calibration Mode Selection */}
+            <CalibrationSetup
+              resolvedMode={requestedCalibrationMode}
+              onSelectMode={setSelectedMode}
+              onStart={() => dispatch({ type: 'START' })}
+              startButtonText="Continue to Instructions"
+            />
+          </div>
         );
 
       case 'pre-test-education':

--- a/web/src/app/test/tobii/page.tsx
+++ b/web/src/app/test/tobii/page.tsx
@@ -19,7 +19,6 @@ import { PreTestSlides } from '@/features/test/components/pre-test-slides';
 import { CalibrationSetup } from '@/features/test/components/calibration/calibration-setup';
 import { SupportedHardware } from '@/features/test/components/supported-hardware';
 import { useTestFlow, useTobiiGazeStream, useTobiiStatus } from '@/features/test/hooks';
-import { Star, Target } from 'lucide-react';
 import { useTobiiTaskBuffers } from '@/features/test/hooks/use-tobii-task-buffers';
 import { submitTobiiTest } from '@/features/test/actions/submit-test';
 import { getTobiiTaskContent } from '@/features/test/lib/test-content';
@@ -40,7 +39,6 @@ export default function TobiiTestPage() {
     checkStatus,
   } = useTobiiStatus();
 
-  const TOBII_SERVICE_URL = process.env.NEXT_PUBLIC_TOBII_SERVICE_URL ?? 'http://localhost:28980';
   const serviceRunning = tobiiStatus?.connected === true;
   const serviceDevice = tobiiStatus?.device;
 
@@ -82,14 +80,6 @@ export default function TobiiTestPage() {
 
   const requestedCalibrationMode = selectedMode || 'grid';
   const participantAge = calibrationParams.age;
-
-  const handleStartTest = useCallback(
-    (mode: CalibrationVisualMode) => {
-      setSelectedMode(mode);
-      dispatch({ type: 'START' });
-    },
-    [dispatch],
-  );
 
   const { enterFullscreen, exitFullscreen } = useFullscreen();
 

--- a/web/src/app/test/tobii/page.tsx
+++ b/web/src/app/test/tobii/page.tsx
@@ -50,7 +50,7 @@ export default function TobiiTestPage() {
       // Launch custom protocol without opening a blank tab
       window.location.href = 'lexora://open';
     } else {
-      window.open('/api/download/service', '_blank');
+      window.location.href = '/api/download/service';
     }
   }, [serviceRunning]);
 

--- a/web/src/app/test/tobii/page.tsx
+++ b/web/src/app/test/tobii/page.tsx
@@ -40,7 +40,7 @@ export default function TobiiTestPage() {
 
   const openTobiiService = useCallback(() => {
     if (typeof window === 'undefined') return;
-    const url = serviceRunning ? TOBII_SERVICE_URL : 'https://github.com/khalilelemam/eglex/releases/latest';
+    const url = serviceRunning ? TOBII_SERVICE_URL : '/api/download/service';
     window.open(url, '_blank');
   }, [serviceRunning, TOBII_SERVICE_URL]);
 

--- a/web/src/app/test/tobii/page.tsx
+++ b/web/src/app/test/tobii/page.tsx
@@ -32,7 +32,12 @@ export default function TobiiTestPage() {
   const router = useRouter();
   const { state, dispatch } = useTestFlow({ mode: 'tobii' });
   const tobiiState = state as TobiiTestFlowState;
-  const { status: tobiiStatus, checking: serviceChecking, error: serviceError, checkStatus } = useTobiiStatus();
+  const {
+    status: tobiiStatus,
+    checking: serviceChecking,
+    error: serviceError,
+    checkStatus,
+  } = useTobiiStatus();
 
   const TOBII_SERVICE_URL = process.env.NEXT_PUBLIC_TOBII_SERVICE_URL ?? 'http://localhost:28980';
   const serviceRunning = tobiiStatus?.connected === true;
@@ -196,7 +201,7 @@ export default function TobiiTestPage() {
     switch (tobiiState.currentState) {
       case 'idle':
         return (
-          <div className="flex flex-col items-center gap-6 w-full max-w-4xl mx-auto">
+          <div className="mx-auto flex w-full max-w-4xl flex-col items-center gap-6">
             <h1 className="text-3xl font-bold">Eye Tracker Test</h1>
             <p className="text-muted-foreground max-w-2xl text-center">
               This test uses a Tobii eye tracker to screen for dyslexia indicators. It consists of 3
@@ -205,7 +210,7 @@ export default function TobiiTestPage() {
 
             {/* Service Status & Supported Devices */}
             <div className="grid w-full gap-6 md:grid-cols-[1fr_auto]">
-              <div className="rounded-3xl border border-border bg-background p-6 shadow-sm">
+              <div className="border-border bg-background rounded-3xl border p-6 shadow-sm">
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                   <div>
                     <p className="text-sm font-semibold">Tobii Service Status</p>
@@ -218,8 +223,8 @@ export default function TobiiTestPage() {
                       serviceChecking
                         ? 'bg-slate-200 text-slate-700'
                         : serviceRunning
-                        ? 'bg-emerald-100 text-emerald-800'
-                        : 'bg-amber-100 text-amber-800'
+                          ? 'bg-emerald-100 text-emerald-800'
+                          : 'bg-amber-100 text-amber-800'
                     }`}
                   >
                     {serviceChecking ? 'Checking…' : serviceRunning ? 'Running' : 'Not running'}
@@ -227,17 +232,23 @@ export default function TobiiTestPage() {
                 </div>
                 {serviceRunning ? (
                   <div className="mt-4 space-y-2 rounded-2xl border border-emerald-100 bg-emerald-50 p-4 text-sm">
-                    <p className="font-medium text-foreground">Connected to the Tobii helper app.</p>
-                    <p className="text-muted-foreground">
-                      {serviceDevice?.deviceName ?? 'Tobii Pro device'} ({serviceDevice?.model ?? 'Unknown model'})
+                    <p className="text-foreground font-medium">
+                      Connected to the Tobii helper app.
                     </p>
-                    <p className="text-muted-foreground text-xs">Serial: {serviceDevice?.serialNumber ?? 'N/A'}</p>
+                    <p className="text-muted-foreground">
+                      {serviceDevice?.deviceName ?? 'Tobii Pro device'} (
+                      {serviceDevice?.model ?? 'Unknown model'})
+                    </p>
+                    <p className="text-muted-foreground text-xs">
+                      Serial: {serviceDevice?.serialNumber ?? 'N/A'}
+                    </p>
                   </div>
                 ) : (
                   <div className="mt-4 space-y-2 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm">
-                    <p className="font-medium text-foreground">Tobii helper is not reachable.</p>
+                    <p className="text-foreground font-medium">Tobii helper is not reachable.</p>
                     <p className="text-muted-foreground">
-                      Install or start the Lexora Tobii Service app on your computer before running the Tobii test.
+                      Install or start the Lexora Tobii Service app on your computer before running
+                      the Tobii test.
                     </p>
                     {serviceError && <p className="text-xs text-amber-700">{serviceError}</p>}
                   </div>
@@ -253,19 +264,20 @@ export default function TobiiTestPage() {
                   <button
                     type="button"
                     onClick={checkStatus}
-                    className="inline-flex items-center justify-center rounded-md border border-border bg-background px-5 py-2 text-sm font-medium text-foreground hover:bg-muted/70"
+                    className="border-border bg-background text-foreground hover:bg-muted/70 inline-flex items-center justify-center rounded-md border px-5 py-2 text-sm font-medium"
                   >
                     Refresh Status
                   </button>
                 </div>
               </div>
 
-              <div className="rounded-3xl border border-border bg-background p-6 shadow-sm">
+              <div className="border-border bg-background rounded-3xl border p-6 shadow-sm">
                 <p className="text-sm font-semibold">Supported Tobii Devices</p>
-                <p className="text-muted-foreground text-xs mb-3">
-                  Lexora supports Tobii Pro devices with SDK support. Consumer trackers such as Tobii Eye Tracker 5 are not compatible.
+                <p className="text-muted-foreground mb-3 text-xs">
+                  Lexora supports Tobii Pro devices with SDK support. Consumer trackers such as
+                  Tobii Eye Tracker 5 are not compatible.
                 </p>
-                <ul className="list-disc space-y-2 pl-4 text-sm text-muted-foreground">
+                <ul className="text-muted-foreground list-disc space-y-2 pl-4 text-sm">
                   <li>Tobii Pro Fusion</li>
                   <li>Tobii Pro Spectrum</li>
                   <li>Tobii Pro Nano</li>

--- a/web/src/app/test/tobii/page.tsx
+++ b/web/src/app/test/tobii/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { FullscreenShell } from '@/components/shared';
 import { StepIndicator } from '@/components/shared';
@@ -16,7 +16,9 @@ import {
   TestErrorBoundary,
 } from '@/features/test/components';
 import { PreTestSlides } from '@/features/test/components/pre-test-slides';
+import { CalibrationSetup } from '@/features/test/components/calibration/calibration-setup';
 import { useTestFlow, useTobiiGazeStream } from '@/features/test/hooks';
+import { Star, Target } from 'lucide-react';
 import { useTobiiTaskBuffers } from '@/features/test/hooks/use-tobii-task-buffers';
 import { submitTobiiTest } from '@/features/test/actions/submit-test';
 import { getTobiiTaskContent } from '@/features/test/lib/test-content';
@@ -49,8 +51,15 @@ export default function TobiiTestPage() {
     };
   }, []);
 
-  const requestedCalibrationMode = calibrationParams.mode;
+  const [selectedMode, setSelectedMode] = useState<CalibrationVisualMode | undefined>(calibrationParams.mode);
+
+  const requestedCalibrationMode = selectedMode || 'grid';
   const participantAge = calibrationParams.age;
+
+  const handleStartTest = useCallback((mode: CalibrationVisualMode) => {
+    setSelectedMode(mode);
+    dispatch({ type: 'START' });
+  }, [dispatch]);
 
   const { enterFullscreen, exitFullscreen } = useFullscreen();
 
@@ -165,6 +174,15 @@ export default function TobiiTestPage() {
 
   const renderState = () => {
     switch (tobiiState.currentState) {
+      case 'idle':
+        return (
+          <CalibrationSetup
+            resolvedMode={requestedCalibrationMode}
+            onSelectMode={setSelectedMode}
+            onStart={() => dispatch({ type: 'START' })}
+            startButtonText="Continue to Instructions"
+          />
+        );
 
       case 'pre-test-education':
         return (

--- a/web/src/app/test/tobii/page.tsx
+++ b/web/src/app/test/tobii/page.tsx
@@ -15,6 +15,7 @@ import {
   ScreenGuard,
   TestErrorBoundary,
 } from '@/features/test/components';
+import { PreTestSlides } from '@/features/test/components/pre-test-slides';
 import { useTestFlow, useTobiiGazeStream } from '@/features/test/hooks';
 import { useTobiiTaskBuffers } from '@/features/test/hooks/use-tobii-task-buffers';
 import { submitTobiiTest } from '@/features/test/actions/submit-test';
@@ -179,6 +180,15 @@ export default function TobiiTestPage() {
               Start Test
             </button>
           </div>
+        );
+
+      case 'pre-test-education':
+        return (
+          <PreTestSlides
+            mode="tobii"
+            onComplete={() => dispatch({ type: 'EDUCATION_COMPLETE' })}
+            onSkip={() => dispatch({ type: 'EDUCATION_COMPLETE' })}
+          />
         );
 
       case 'device-check':

--- a/web/src/app/test/tobii/page.tsx
+++ b/web/src/app/test/tobii/page.tsx
@@ -165,27 +165,12 @@ export default function TobiiTestPage() {
 
   const renderState = () => {
     switch (tobiiState.currentState) {
-      case 'idle':
-        return (
-          <div className="flex flex-col items-center gap-6">
-            <h1 className="font-bold text-3xl">Eye Tracker Test</h1>
-            <p className="text-muted-foreground">
-              This test uses a Tobii eye tracker to screen for dyslexia indicators. It consists of 3
-              reading tasks: syllables, pseudo-words, and meaningful text.
-            </p>
-            <button
-              onClick={() => dispatch({ type: 'START' })}
-              className="bg-primary hover:bg-primary/90 px-6 py-3 rounded-md font-medium text-primary-foreground text-lg"
-            >
-              Start Test
-            </button>
-          </div>
-        );
 
       case 'pre-test-education':
         return (
           <PreTestSlides
             mode="tobii"
+            isStarMode={requestedCalibrationMode === 'star'}
             onComplete={() => dispatch({ type: 'EDUCATION_COMPLETE' })}
             onSkip={() => dispatch({ type: 'EDUCATION_COMPLETE' })}
           />

--- a/web/src/app/test/tobii/page.tsx
+++ b/web/src/app/test/tobii/page.tsx
@@ -51,15 +51,20 @@ export default function TobiiTestPage() {
     };
   }, []);
 
-  const [selectedMode, setSelectedMode] = useState<CalibrationVisualMode | undefined>(calibrationParams.mode);
+  const [selectedMode, setSelectedMode] = useState<CalibrationVisualMode | undefined>(
+    calibrationParams.mode,
+  );
 
   const requestedCalibrationMode = selectedMode || 'grid';
   const participantAge = calibrationParams.age;
 
-  const handleStartTest = useCallback((mode: CalibrationVisualMode) => {
-    setSelectedMode(mode);
-    dispatch({ type: 'START' });
-  }, [dispatch]);
+  const handleStartTest = useCallback(
+    (mode: CalibrationVisualMode) => {
+      setSelectedMode(mode);
+      dispatch({ type: 'START' });
+    },
+    [dispatch],
+  );
 
   const { enterFullscreen, exitFullscreen } = useFullscreen();
 

--- a/web/src/app/test/tobii/page.tsx
+++ b/web/src/app/test/tobii/page.tsx
@@ -45,9 +45,13 @@ export default function TobiiTestPage() {
 
   const openTobiiService = useCallback(() => {
     if (typeof window === 'undefined') return;
-    const url = serviceRunning ? TOBII_SERVICE_URL : '/api/download/service';
-    window.open(url, '_blank');
-  }, [serviceRunning, TOBII_SERVICE_URL]);
+    if (serviceRunning) {
+      // Launch custom protocol without opening a blank tab
+      window.location.href = 'lexora://open';
+    } else {
+      window.open('/api/download/service', '_blank');
+    }
+  }, [serviceRunning]);
 
   useEffect(() => {
     checkStatus();

--- a/web/src/app/test/webcam/page.tsx
+++ b/web/src/app/test/webcam/page.tsx
@@ -211,28 +211,12 @@ export default function WebcamTestPage() {
 
   const renderState = () => {
     switch (webcamState.currentState) {
-      case 'idle':
-        return (
-          <div className="flex flex-col items-center gap-6">
-            <h1 className="text-3xl font-bold">Webcam Eye Test</h1>
-            <p className="text-muted-foreground max-w-lg text-center">
-              This test uses your webcam to track eye movement while reading a paragraph. It&apos;s
-              less accurate than a professional eye tracker but doesn&apos;t require special
-              hardware.
-            </p>
-            <button
-              onClick={() => dispatch({ type: 'START' })}
-              className="bg-primary hover:bg-primary/90 text-primary-foreground rounded-md px-6 py-3 text-lg font-medium"
-            >
-              Start Test
-            </button>
-          </div>
-        );
 
       case 'pre-test-education':
         return (
           <PreTestSlides
             mode="webcam"
+            isStarMode={requestedCalibrationMode === 'star'}
             onComplete={() => dispatch({ type: 'EDUCATION_COMPLETE' })}
             onSkip={() => dispatch({ type: 'EDUCATION_COMPLETE' })}
           />

--- a/web/src/app/test/webcam/page.tsx
+++ b/web/src/app/test/webcam/page.tsx
@@ -55,15 +55,20 @@ export default function WebcamTestPage() {
     };
   }, []);
 
-  const [selectedMode, setSelectedMode] = useState<CalibrationVisualMode | undefined>(calibrationParams.mode);
+  const [selectedMode, setSelectedMode] = useState<CalibrationVisualMode | undefined>(
+    calibrationParams.mode,
+  );
 
   const requestedCalibrationMode = selectedMode || 'grid';
   const participantAge = calibrationParams.age;
 
-  const handleStartTest = useCallback((mode: CalibrationVisualMode) => {
-    setSelectedMode(mode);
-    dispatch({ type: 'START' });
-  }, [dispatch]);
+  const handleStartTest = useCallback(
+    (mode: CalibrationVisualMode) => {
+      setSelectedMode(mode);
+      dispatch({ type: 'START' });
+    },
+    [dispatch],
+  );
 
   const { enterFullscreen, exitFullscreen } = useFullscreen();
 

--- a/web/src/app/test/webcam/page.tsx
+++ b/web/src/app/test/webcam/page.tsx
@@ -19,7 +19,6 @@ import {
 import { PreTestSlides } from '@/features/test/components/pre-test-slides';
 import { CalibrationSetup } from '@/features/test/components/calibration/calibration-setup';
 import { useTestFlow, useWebcamGaze } from '@/features/test/hooks';
-import { Star, Target } from 'lucide-react';
 import { useFullscreen } from '@/features/test/hooks/use-fullscreen';
 import { submitWebcamTest } from '@/features/test/actions/submit-test';
 import { getWebcamTaskContent } from '@/features/test/lib/test-content';
@@ -61,14 +60,6 @@ export default function WebcamTestPage() {
 
   const requestedCalibrationMode = selectedMode || 'grid';
   const participantAge = calibrationParams.age;
-
-  const handleStartTest = useCallback(
-    (mode: CalibrationVisualMode) => {
-      setSelectedMode(mode);
-      dispatch({ type: 'START' });
-    },
-    [dispatch],
-  );
 
   const { enterFullscreen, exitFullscreen } = useFullscreen();
 

--- a/web/src/app/test/webcam/page.tsx
+++ b/web/src/app/test/webcam/page.tsx
@@ -17,7 +17,9 @@ import {
   TestErrorBoundary,
 } from '@/features/test/components';
 import { PreTestSlides } from '@/features/test/components/pre-test-slides';
+import { CalibrationSetup } from '@/features/test/components/calibration/calibration-setup';
 import { useTestFlow, useWebcamGaze } from '@/features/test/hooks';
+import { Star, Target } from 'lucide-react';
 import { useFullscreen } from '@/features/test/hooks/use-fullscreen';
 import { submitWebcamTest } from '@/features/test/actions/submit-test';
 import { getWebcamTaskContent } from '@/features/test/lib/test-content';
@@ -53,8 +55,15 @@ export default function WebcamTestPage() {
     };
   }, []);
 
-  const requestedCalibrationMode = calibrationParams.mode;
+  const [selectedMode, setSelectedMode] = useState<CalibrationVisualMode | undefined>(calibrationParams.mode);
+
+  const requestedCalibrationMode = selectedMode || 'grid';
   const participantAge = calibrationParams.age;
+
+  const handleStartTest = useCallback((mode: CalibrationVisualMode) => {
+    setSelectedMode(mode);
+    dispatch({ type: 'START' });
+  }, [dispatch]);
 
   const { enterFullscreen, exitFullscreen } = useFullscreen();
 
@@ -211,6 +220,15 @@ export default function WebcamTestPage() {
 
   const renderState = () => {
     switch (webcamState.currentState) {
+      case 'idle':
+        return (
+          <CalibrationSetup
+            resolvedMode={requestedCalibrationMode}
+            onSelectMode={setSelectedMode}
+            onStart={() => dispatch({ type: 'START' })}
+            startButtonText="Continue to Instructions"
+          />
+        );
 
       case 'pre-test-education':
         return (

--- a/web/src/app/test/webcam/page.tsx
+++ b/web/src/app/test/webcam/page.tsx
@@ -16,6 +16,7 @@ import {
   GazeDebugDot,
   TestErrorBoundary,
 } from '@/features/test/components';
+import { PreTestSlides } from '@/features/test/components/pre-test-slides';
 import { useTestFlow, useWebcamGaze } from '@/features/test/hooks';
 import { useFullscreen } from '@/features/test/hooks/use-fullscreen';
 import { submitWebcamTest } from '@/features/test/actions/submit-test';
@@ -226,6 +227,15 @@ export default function WebcamTestPage() {
               Start Test
             </button>
           </div>
+        );
+
+      case 'pre-test-education':
+        return (
+          <PreTestSlides
+            mode="webcam"
+            onComplete={() => dispatch({ type: 'EDUCATION_COMPLETE' })}
+            onSkip={() => dispatch({ type: 'EDUCATION_COMPLETE' })}
+          />
         );
 
       case 'camera-setup':

--- a/web/src/features/test/components/calibration-screen.tsx
+++ b/web/src/features/test/components/calibration-screen.tsx
@@ -59,7 +59,6 @@ export function CalibrationScreen({
 }: CalibrationScreenProps) {
   /* ---- local state ---- */
   const [selectedMode, setSelectedMode] = useState<CalibrationVisualMode | undefined>(mode);
-  const [hasStartedCalibration, setHasStartedCalibration] = useState(false);
   const [collectionIssue, setCollectionIssue] = useState<'no-signal' | 'low-samples' | null>(null);
 
   /* ---- engine ---- */
@@ -112,6 +111,10 @@ export function CalibrationScreen({
   const [previousPoint, setPreviousPoint] = useState<CalibrationPoint>(CALIBRATION_POINTS[0]);
   const captureCountRef = useRef(0);
   const stableFixationRef = useRef(false);
+
+  useEffect(() => {
+    beginCalibration();
+  }, [beginCalibration]);
 
   useEffect(() => {
     captureCountRef.current = captureCount;
@@ -218,16 +221,9 @@ export function CalibrationScreen({
   /* ---- callbacks ---- */
   const handleRetry = useCallback(() => {
     resetEngine();
-    setHasStartedCalibration(false);
     setCollectionIssue(null);
     setDismissedValidationRound(null);
   }, [resetEngine]);
-
-  const handleStartCalibration = useCallback(() => {
-    beginCalibration();
-    setHasStartedCalibration(true);
-    setCollectionIssue(null);
-  }, [beginCalibration]);
 
   const handleSkip = useCallback(() => {
     skipCalibration();
@@ -264,17 +260,6 @@ export function CalibrationScreen({
   /* ================================================================ */
   /*  RENDER — delegates to extracted sub-components                   */
   /* ================================================================ */
-
-  /* 1. Setup (mode selection + instructions) */
-  if (!hasStartedCalibration) {
-    return (
-      <CalibrationSetup
-        resolvedMode={resolvedMode}
-        onSelectMode={setSelectedMode}
-        onStart={handleStartCalibration}
-      />
-    );
-  }
 
   /* 2. Countdown */
   if (showCountdown) {

--- a/web/src/features/test/components/calibration-screen.tsx
+++ b/web/src/features/test/components/calibration-screen.tsx
@@ -12,7 +12,6 @@ import {
   useCalibrationEngine,
 } from '../hooks/use-calibration-engine';
 import {
-  CalibrationSetup,
   CalibrationCountdown,
   CalibrationCollecting,
   CalibrationPreValidation,
@@ -58,7 +57,6 @@ export function CalibrationScreen({
   blockOnPoor = false,
 }: CalibrationScreenProps) {
   /* ---- local state ---- */
-  const [selectedMode, setSelectedMode] = useState<CalibrationVisualMode | undefined>(mode);
   const [collectionIssue, setCollectionIssue] = useState<'no-signal' | 'low-samples' | null>(null);
 
   /* ---- engine ---- */
@@ -84,7 +82,7 @@ export function CalibrationScreen({
     readyForPreValidation,
   } = useCalibrationEngine({
     tracker,
-    mode: selectedMode,
+    mode: mode,
     participantAge,
     onGetGazeSample,
     onGetIrisSample,

--- a/web/src/features/test/components/calibration/calibration-setup.tsx
+++ b/web/src/features/test/components/calibration/calibration-setup.tsx
@@ -21,7 +21,12 @@ interface CalibrationSetupProps {
  * Left: Instructions + fullscreen consent + start button
  * Right: Mode selection cards
  */
-export function CalibrationSetup({ resolvedMode, onSelectMode, onStart, startButtonText = "Enter Fullscreen & Start Calibration" }: CalibrationSetupProps) {
+export function CalibrationSetup({
+  resolvedMode,
+  onSelectMode,
+  onStart,
+  startButtonText = 'Enter Fullscreen & Start Calibration',
+}: CalibrationSetupProps) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center overflow-auto bg-[#FDF8F0] px-4 py-6">
       <div

--- a/web/src/features/test/components/calibration/calibration-setup.tsx
+++ b/web/src/features/test/components/calibration/calibration-setup.tsx
@@ -12,6 +12,7 @@ interface CalibrationSetupProps {
   resolvedMode: CalibrationVisualMode;
   onSelectMode: (mode: CalibrationVisualMode) => void;
   onStart: () => void;
+  startButtonText?: string;
 }
 
 /**
@@ -20,7 +21,7 @@ interface CalibrationSetupProps {
  * Left: Instructions + fullscreen consent + start button
  * Right: Mode selection cards
  */
-export function CalibrationSetup({ resolvedMode, onSelectMode, onStart }: CalibrationSetupProps) {
+export function CalibrationSetup({ resolvedMode, onSelectMode, onStart, startButtonText = "Enter Fullscreen & Start Calibration" }: CalibrationSetupProps) {
   return (
     <div className="z-50 fixed inset-0 flex justify-center items-center bg-[#FDF8F0] px-4 py-6 overflow-auto">
       <div
@@ -70,7 +71,7 @@ export function CalibrationSetup({ resolvedMode, onSelectMode, onStart }: Calibr
             size="lg"
             className="bg-[#4A7C59] hover:bg-[#3D6A4B] mt-auto px-10 w-full text-white"
           >
-            Enter Fullscreen & Start Calibration
+            {startButtonText}
           </Button>
         </div>
 

--- a/web/src/features/test/components/device-check.tsx
+++ b/web/src/features/test/components/device-check.tsx
@@ -156,7 +156,7 @@ export function DeviceCheck({ onReady }: DeviceCheckProps) {
               <Button
                 variant="secondary"
                 size="sm"
-                onClick={() => window.open('/api/download/service', '_blank')}
+                onClick={() => { window.location.href = '/api/download/service'; }}
               >
                 Download Service
               </Button>
@@ -279,7 +279,7 @@ export function DeviceCheck({ onReady }: DeviceCheckProps) {
                 <Button
                   variant="secondary"
                   size="sm"
-                  onClick={() => window.open('/api/download/service', '_blank')}
+                  onClick={() => { window.location.href = '/api/download/service'; }}
                 >
                   Download Service
                 </Button>

--- a/web/src/features/test/components/device-check.tsx
+++ b/web/src/features/test/components/device-check.tsx
@@ -121,12 +121,10 @@ export function DeviceCheck({ onReady }: DeviceCheckProps) {
                 <li>Make sure it shows a green status indicator</li>
               </ol>
               <a
-                href="https://github.com/khalilelemam/eglex/releases"
-                target="_blank"
-                rel="noopener noreferrer"
+                href="/api/download/service"
                 className="text-primary inline-flex items-center gap-1.5 text-xs font-medium underline-offset-4 hover:underline"
               >
-                Download from GitHub Releases
+                Download Tobii Service
                 <ExternalLink className="h-3 w-3" />
               </a>
             </div>
@@ -157,7 +155,7 @@ export function DeviceCheck({ onReady }: DeviceCheckProps) {
               <Button
                 variant="secondary"
                 size="sm"
-                onClick={() => window.open('https://github.com/khalilelemam/eglex/releases/latest', '_blank')}
+                onClick={() => window.open('/api/download/service', '_blank')}
               >
                 Download Service
               </Button>
@@ -280,7 +278,7 @@ export function DeviceCheck({ onReady }: DeviceCheckProps) {
                 <Button
                   variant="secondary"
                   size="sm"
-                  onClick={() => window.open('https://github.com/khalilelemam/eglex/releases/latest', '_blank')}
+                  onClick={() => window.open('/api/download/service', '_blank')}
                 >
                   Download Service
                 </Button>

--- a/web/src/features/test/components/device-check.tsx
+++ b/web/src/features/test/components/device-check.tsx
@@ -288,7 +288,7 @@ export function DeviceCheck({ onReady }: DeviceCheckProps) {
                 <Button
                   variant="secondary"
                   size="sm"
-                  onClick={() => window.open('http://localhost:28980', '_blank')}
+                  onClick={() => { window.location.href = 'lexora://open'; }}
                 >
                   Open Service
                 </Button>

--- a/web/src/features/test/components/device-check.tsx
+++ b/web/src/features/test/components/device-check.tsx
@@ -131,7 +131,19 @@ export function DeviceCheck({ onReady }: DeviceCheckProps) {
               </a>
             </div>
 
-            <div className="flex gap-3 pt-1">
+            <div className="rounded-2xl border border-border bg-background p-4 text-sm text-muted-foreground">
+              <p className="mb-2 text-xs font-semibold text-foreground">Supported Tobii Devices</p>
+              <ul className="list-disc space-y-1 pl-4">
+                <li>Tobii Pro Fusion</li>
+                <li>Tobii Pro Spectrum</li>
+                <li>Tobii Pro Nano</li>
+              </ul>
+              <p className="mt-3 text-xs text-muted-foreground">
+                Only Tobii Pro devices with SDK support are compatible. Consumer trackers such as Tobii Eye Tracker 5 are not supported.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-3 pt-1">
               <Button
                 variant="outline"
                 size="sm"
@@ -141,6 +153,13 @@ export function DeviceCheck({ onReady }: DeviceCheckProps) {
                 }}
               >
                 Already installed? Skip →
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => window.open('https://github.com/khalilelemam/eglex/releases/latest', '_blank')}
+              >
+                Download Service
               </Button>
               <Button size="sm" onClick={() => setStep('connect')}>
                 I&apos;ve installed it
@@ -249,7 +268,7 @@ export function DeviceCheck({ onReady }: DeviceCheckProps) {
               </div>
             )}
 
-            <div className="flex gap-3 pt-1">
+            <div className="flex flex-wrap gap-3 pt-1">
               <Button variant="outline" size="sm" onClick={() => setStep('install')}>
                 ← Start Over
               </Button>
@@ -257,6 +276,24 @@ export function DeviceCheck({ onReady }: DeviceCheckProps) {
                 <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${checking ? 'animate-spin' : ''}`} />
                 Retry
               </Button>
+              {!isConnected && (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => window.open('https://github.com/khalilelemam/eglex/releases/latest', '_blank')}
+                >
+                  Download Service
+                </Button>
+              )}
+              {isConnected && (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => window.open('http://localhost:28980', '_blank')}
+                >
+                  Open Service
+                </Button>
+              )}
               {isConnected && (
                 <Button size="sm" onClick={onReady} className="px-6">
                   Continue to Calibration

--- a/web/src/features/test/components/device-check.tsx
+++ b/web/src/features/test/components/device-check.tsx
@@ -156,7 +156,9 @@ export function DeviceCheck({ onReady }: DeviceCheckProps) {
               <Button
                 variant="secondary"
                 size="sm"
-                onClick={() => { window.location.href = '/api/download/service'; }}
+                onClick={() => {
+                  window.location.href = '/api/download/service';
+                }}
               >
                 Download Service
               </Button>
@@ -279,7 +281,9 @@ export function DeviceCheck({ onReady }: DeviceCheckProps) {
                 <Button
                   variant="secondary"
                   size="sm"
-                  onClick={() => { window.location.href = '/api/download/service'; }}
+                  onClick={() => {
+                    window.location.href = '/api/download/service';
+                  }}
                 >
                   Download Service
                 </Button>
@@ -288,7 +292,9 @@ export function DeviceCheck({ onReady }: DeviceCheckProps) {
                 <Button
                   variant="secondary"
                   size="sm"
-                  onClick={() => { window.location.href = 'lexora://open'; }}
+                  onClick={() => {
+                    window.location.href = 'lexora://open';
+                  }}
                 >
                   Open Service
                 </Button>

--- a/web/src/features/test/components/device-check.tsx
+++ b/web/src/features/test/components/device-check.tsx
@@ -129,15 +129,16 @@ export function DeviceCheck({ onReady }: DeviceCheckProps) {
               </a>
             </div>
 
-            <div className="rounded-2xl border border-border bg-background p-4 text-sm text-muted-foreground">
-              <p className="mb-2 text-xs font-semibold text-foreground">Supported Tobii Devices</p>
+            <div className="border-border bg-background text-muted-foreground rounded-2xl border p-4 text-sm">
+              <p className="text-foreground mb-2 text-xs font-semibold">Supported Tobii Devices</p>
               <ul className="list-disc space-y-1 pl-4">
                 <li>Tobii Pro Fusion</li>
                 <li>Tobii Pro Spectrum</li>
                 <li>Tobii Pro Nano</li>
               </ul>
-              <p className="mt-3 text-xs text-muted-foreground">
-                Only Tobii Pro devices with SDK support are compatible. Consumer trackers such as Tobii Eye Tracker 5 are not supported.
+              <p className="text-muted-foreground mt-3 text-xs">
+                Only Tobii Pro devices with SDK support are compatible. Consumer trackers such as
+                Tobii Eye Tracker 5 are not supported.
               </p>
             </div>
 

--- a/web/src/features/test/components/pre-test-slides.tsx
+++ b/web/src/features/test/components/pre-test-slides.tsx
@@ -2,15 +2,7 @@
 
 import React, { useState, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import {
-  Monitor,
-  Sun,
-  Star,
-  Shield,
-  ArrowRight,
-  ArrowLeft,
-  ChevronRight,
-} from 'lucide-react';
+import { Monitor, Sun, Star, Shield, ArrowRight, ArrowLeft, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { LexoraLogo } from '@/components/shared/lexora-logo';
 import { cn } from '@/lib/utils';

--- a/web/src/features/test/components/pre-test-slides.tsx
+++ b/web/src/features/test/components/pre-test-slides.tsx
@@ -3,9 +3,7 @@
 import React, { useState, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-  Eye,
   Monitor,
-  BookOpen,
   Sun,
   Star,
   Shield,

--- a/web/src/features/test/components/pre-test-slides.tsx
+++ b/web/src/features/test/components/pre-test-slides.tsx
@@ -37,15 +37,15 @@ interface Slide {
 }
 
 const WelcomeVisual = () => (
-  <div className="relative w-full h-full flex items-center justify-center bg-[#4A7C59]/5">
-    <motion.div 
-      className="w-24 h-24 border-4 border-[#4A7C59] rounded-full flex items-center justify-center relative shadow-sm bg-white"
+  <div className="relative flex h-full w-full items-center justify-center bg-[#4A7C59]/5">
+    <motion.div
+      className="relative flex h-24 w-24 items-center justify-center rounded-full border-4 border-[#4A7C59] bg-white shadow-sm"
       initial={{ scale: 0.9 }}
       animate={{ scale: 1 }}
       transition={{ duration: 2, repeat: Infinity, repeatType: 'reverse', ease: 'easeInOut' }}
     >
-      <motion.div 
-        className="w-8 h-8 bg-[#4A7C59] rounded-full shadow-inner"
+      <motion.div
+        className="h-8 w-8 rounded-full bg-[#4A7C59] shadow-inner"
         animate={{ x: [-24, 24, -24, 0] }}
         transition={{ duration: 4, repeat: Infinity, ease: 'easeInOut' }}
       />
@@ -54,112 +54,144 @@ const WelcomeVisual = () => (
 );
 
 const CalibrationVisual = () => (
-  <div className="relative w-full h-full bg-[#4A7C59]/5">
-    <div className="absolute w-4 h-4 bg-[#4A7C59]/30 rounded-full" style={{ top: '15%', left: '15%', transform: 'translate(-50%, -50%)' }} />
-    <div className="absolute w-4 h-4 bg-[#4A7C59]/30 rounded-full" style={{ top: '15%', left: '85%', transform: 'translate(-50%, -50%)' }} />
-    <div className="absolute w-4 h-4 bg-[#4A7C59]/30 rounded-full" style={{ top: '85%', left: '15%', transform: 'translate(-50%, -50%)' }} />
-    <div className="absolute w-4 h-4 bg-[#4A7C59]/30 rounded-full" style={{ top: '85%', left: '85%', transform: 'translate(-50%, -50%)' }} />
-    
-    <motion.div 
-      className="absolute w-8 h-8 rounded-full border-4 border-[#4A7C59] flex items-center justify-center bg-white shadow-md"
+  <div className="relative h-full w-full bg-[#4A7C59]/5">
+    <div
+      className="absolute h-4 w-4 rounded-full bg-[#4A7C59]/30"
+      style={{ top: '15%', left: '15%', transform: 'translate(-50%, -50%)' }}
+    />
+    <div
+      className="absolute h-4 w-4 rounded-full bg-[#4A7C59]/30"
+      style={{ top: '15%', left: '85%', transform: 'translate(-50%, -50%)' }}
+    />
+    <div
+      className="absolute h-4 w-4 rounded-full bg-[#4A7C59]/30"
+      style={{ top: '85%', left: '15%', transform: 'translate(-50%, -50%)' }}
+    />
+    <div
+      className="absolute h-4 w-4 rounded-full bg-[#4A7C59]/30"
+      style={{ top: '85%', left: '85%', transform: 'translate(-50%, -50%)' }}
+    />
+
+    <motion.div
+      className="absolute flex h-8 w-8 items-center justify-center rounded-full border-4 border-[#4A7C59] bg-white shadow-md"
       style={{ x: '-50%', y: '-50%' }}
-      animate={{ 
+      animate={{
         top: ['15%', '15%', '85%', '85%', '50%'],
         left: ['15%', '85%', '15%', '85%', '50%'],
-        scale: [1, 0.6, 1, 0.6, 1, 0.6, 1, 0.6, 1]
+        scale: [1, 0.6, 1, 0.6, 1, 0.6, 1, 0.6, 1],
       }}
       transition={{ duration: 6, repeat: Infinity, ease: 'easeInOut' }}
     >
-       <motion.div 
-         className="w-3 h-3 bg-[#4A7C59] rounded-full" 
-         animate={{ scale: [0.3, 1, 0.3] }} 
-         transition={{ duration: 1.5, repeat: Infinity }} 
-       />
+      <motion.div
+        className="h-3 w-3 rounded-full bg-[#4A7C59]"
+        animate={{ scale: [0.3, 1, 0.3] }}
+        transition={{ duration: 1.5, repeat: Infinity }}
+      />
     </motion.div>
   </div>
 );
 
 const StarGameVisual = () => (
-  <div className="relative w-full h-full bg-amber-500/5">
-    <div className="absolute w-4 h-4 bg-amber-500/30 rounded-full" style={{ top: '15%', left: '15%', transform: 'translate(-50%, -50%)' }} />
-    <div className="absolute w-4 h-4 bg-amber-500/30 rounded-full" style={{ top: '15%', left: '85%', transform: 'translate(-50%, -50%)' }} />
-    <div className="absolute w-4 h-4 bg-amber-500/30 rounded-full" style={{ top: '85%', left: '15%', transform: 'translate(-50%, -50%)' }} />
-    <div className="absolute w-4 h-4 bg-amber-500/30 rounded-full" style={{ top: '85%', left: '85%', transform: 'translate(-50%, -50%)' }} />
-    
-    <motion.div 
-      className="absolute w-16 h-16 flex items-center justify-center text-amber-400 drop-shadow-md"
+  <div className="relative h-full w-full bg-amber-500/5">
+    <div
+      className="absolute h-4 w-4 rounded-full bg-amber-500/30"
+      style={{ top: '15%', left: '15%', transform: 'translate(-50%, -50%)' }}
+    />
+    <div
+      className="absolute h-4 w-4 rounded-full bg-amber-500/30"
+      style={{ top: '15%', left: '85%', transform: 'translate(-50%, -50%)' }}
+    />
+    <div
+      className="absolute h-4 w-4 rounded-full bg-amber-500/30"
+      style={{ top: '85%', left: '15%', transform: 'translate(-50%, -50%)' }}
+    />
+    <div
+      className="absolute h-4 w-4 rounded-full bg-amber-500/30"
+      style={{ top: '85%', left: '85%', transform: 'translate(-50%, -50%)' }}
+    />
+
+    <motion.div
+      className="absolute flex h-16 w-16 items-center justify-center text-amber-400 drop-shadow-md"
       style={{ x: '-50%', y: '-50%' }}
-      animate={{ 
+      animate={{
         top: ['15%', '15%', '85%', '85%', '50%'],
         left: ['15%', '85%', '15%', '85%', '50%'],
-        scale: [1, 0.2, 1, 0.2, 1, 0.2, 1, 0.2, 1]
+        scale: [1, 0.2, 1, 0.2, 1, 0.2, 1, 0.2, 1],
       }}
       transition={{ duration: 8, repeat: Infinity, ease: 'easeInOut' }}
     >
-       <motion.div
-         animate={{ rotate: [0, 5, 0, -5, 0] }}
-         transition={{ duration: 1.2, repeat: Infinity, ease: 'easeInOut' }}
-       >
-         <Star className="w-16 h-16 fill-amber-400/80" />
-       </motion.div>
+      <motion.div
+        animate={{ rotate: [0, 5, 0, -5, 0] }}
+        transition={{ duration: 1.2, repeat: Infinity, ease: 'easeInOut' }}
+      >
+        <Star className="h-16 w-16 fill-amber-400/80" />
+      </motion.div>
     </motion.div>
   </div>
 );
 
 const PositionVisual = () => (
-  <div className="relative w-full h-full flex items-center justify-center bg-[#4A7C59]/5 overflow-hidden">
-    <div className="w-1/2 h-3/4 border-4 border-[#4A7C59]/30 rounded-2xl flex items-center justify-center bg-white shadow-sm">
-       <motion.div 
-         className="w-16 h-20 border-2 border-dashed border-[#4A7C59] rounded-[2rem]"
-         animate={{ scale: [0.9, 1.1, 1], opacity: [0.4, 1, 0.4] }}
-         transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
-       />
+  <div className="relative flex h-full w-full items-center justify-center overflow-hidden bg-[#4A7C59]/5">
+    <div className="flex h-3/4 w-1/2 items-center justify-center rounded-2xl border-4 border-[#4A7C59]/30 bg-white shadow-sm">
+      <motion.div
+        className="h-20 w-16 rounded-[2rem] border-2 border-dashed border-[#4A7C59]"
+        animate={{ scale: [0.9, 1.1, 1], opacity: [0.4, 1, 0.4] }}
+        transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
+      />
     </div>
-    <motion.div 
-       className="absolute top-4 right-6 text-amber-400"
-       animate={{ rotate: 360, scale: [1, 1.2, 1] }}
-       transition={{ duration: 8, repeat: Infinity, ease: 'linear' }}
+    <motion.div
+      className="absolute top-4 right-6 text-amber-400"
+      animate={{ rotate: 360, scale: [1, 1.2, 1] }}
+      transition={{ duration: 8, repeat: Infinity, ease: 'linear' }}
     >
-       <Sun className="w-12 h-12 fill-amber-400/20" />
+      <Sun className="h-12 w-12 fill-amber-400/20" />
     </motion.div>
   </div>
 );
 
 const SecureVisual = () => (
-  <div className="relative w-full h-full flex flex-col items-center justify-center gap-6 bg-[#4A7C59]/5">
-     <Monitor className="w-16 h-16 text-[#4A7C59]" strokeWidth={1.5} />
-     <div className="flex gap-3">
-       {[0,1,2].map(i => (
-         <motion.div 
-           key={i}
-           className="w-2.5 h-2.5 bg-[#4A7C59] rounded-full"
-           animate={{ y: [0, -12, 0], opacity: [0.2, 1, 0.2] }}
-           transition={{ duration: 1.5, repeat: Infinity, delay: i * 0.2, ease: 'easeInOut' }}
-         />
-       ))}
-     </div>
-     <div className="relative">
-       <Shield className="w-12 h-12 text-[#4A7C59]" strokeWidth={1.5} />
-       <motion.div 
-         className="absolute inset-0 bg-[#4A7C59] rounded-full blur-xl -z-10"
-         animate={{ opacity: [0.1, 0.4, 0.1], scale: [0.8, 1.5, 0.8] }}
-         transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
-       />
-     </div>
+  <div className="relative flex h-full w-full flex-col items-center justify-center gap-6 bg-[#4A7C59]/5">
+    <Monitor className="h-16 w-16 text-[#4A7C59]" strokeWidth={1.5} />
+    <div className="flex gap-3">
+      {[0, 1, 2].map((i) => (
+        <motion.div
+          key={i}
+          className="h-2.5 w-2.5 rounded-full bg-[#4A7C59]"
+          animate={{ y: [0, -12, 0], opacity: [0.2, 1, 0.2] }}
+          transition={{ duration: 1.5, repeat: Infinity, delay: i * 0.2, ease: 'easeInOut' }}
+        />
+      ))}
+    </div>
+    <div className="relative">
+      <Shield className="h-12 w-12 text-[#4A7C59]" strokeWidth={1.5} />
+      <motion.div
+        className="absolute inset-0 -z-10 rounded-full bg-[#4A7C59] blur-xl"
+        animate={{ opacity: [0.1, 0.4, 0.1], scale: [0.8, 1.5, 0.8] }}
+        transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
+      />
+    </div>
   </div>
 );
 
 const PrivacyVisual = () => (
-  <div className="relative w-full h-full flex items-center justify-center bg-[#4A7C59]/5">
-     <motion.div
-       animate={{ rotateY: [0, 180, 360] }}
-       transition={{ duration: 4, repeat: Infinity, ease: 'linear' }}
-       style={{ transformStyle: 'preserve-3d' }}
-     >
-       <Shield className="w-24 h-24 text-[#4A7C59] fill-[#4A7C59]/10" strokeWidth={1.5} />
-     </motion.div>
-     <motion.div className="absolute top-1/4 right-1/4 w-3 h-3 bg-[#4A7C59]/40 rounded-full" animate={{ scale: [0, 1.5, 0] }} transition={{ duration: 2, repeat: Infinity, delay: 0.5 }} />
-     <motion.div className="absolute bottom-1/4 left-1/4 w-4 h-4 bg-[#4A7C59]/40 rounded-full" animate={{ scale: [0, 1.5, 0] }} transition={{ duration: 2, repeat: Infinity, delay: 1.5 }} />
+  <div className="relative flex h-full w-full items-center justify-center bg-[#4A7C59]/5">
+    <motion.div
+      animate={{ rotateY: [0, 180, 360] }}
+      transition={{ duration: 4, repeat: Infinity, ease: 'linear' }}
+      style={{ transformStyle: 'preserve-3d' }}
+    >
+      <Shield className="h-24 w-24 fill-[#4A7C59]/10 text-[#4A7C59]" strokeWidth={1.5} />
+    </motion.div>
+    <motion.div
+      className="absolute top-1/4 right-1/4 h-3 w-3 rounded-full bg-[#4A7C59]/40"
+      animate={{ scale: [0, 1.5, 0] }}
+      transition={{ duration: 2, repeat: Infinity, delay: 0.5 }}
+    />
+    <motion.div
+      className="absolute bottom-1/4 left-1/4 h-4 w-4 rounded-full bg-[#4A7C59]/40"
+      animate={{ scale: [0, 1.5, 0] }}
+      transition={{ duration: 2, repeat: Infinity, delay: 1.5 }}
+    />
   </div>
 );
 
@@ -168,7 +200,8 @@ function getSlides(mode: 'tobii' | 'webcam', isStarMode: boolean): Slide[] {
     ? {
         visual: <StarGameVisual />,
         title: 'Catch the Stars!',
-        description: 'Look directly at the glowing stars when they appear on the screen. They will magically shrink and vanish when you catch them with your eyes!',
+        description:
+          'Look directly at the glowing stars when they appear on the screen. They will magically shrink and vanish when you catch them with your eyes!',
         tips: [
           'Keep your eyes fixed on the star until it disappears',
           'Have fun and try to catch all of them!',
@@ -177,14 +210,14 @@ function getSlides(mode: 'tobii' | 'webcam', isStarMode: boolean): Slide[] {
       }
     : {
         visual: <CalibrationVisual />,
-        title: 'What You\'ll Do',
+        title: "What You'll Do",
         description:
           mode === 'tobii'
             ? 'Follow the dots to calibrate, then complete 3 short reading tasks.'
             : 'Follow the dots to calibrate, then read a short paragraph naturally.',
         tips: [
           'Follow the calibration dots with your eyes',
-          'Read the text naturally — don\'t rush',
+          "Read the text naturally — don't rush",
           'Get instant results immediately after',
         ],
       };
@@ -203,7 +236,7 @@ function getSlides(mode: 'tobii' | 'webcam', isStarMode: boolean): Slide[] {
       title: 'Prepare Your Space',
       description: 'Good conditions ensure accurate tracking.',
       tips: [
-        'Sit directly at arm\'s length from the screen',
+        "Sit directly at arm's length from the screen",
         'Ensure even lighting — avoid bright backlight',
         'Remove glasses if possible to reduce glare',
         mode === 'webcam' ? 'Ensure your webcam is clean' : 'Ensure your Tobii is connected',
@@ -256,7 +289,12 @@ function getSlides(mode: 'tobii' | 'webcam', isStarMode: boolean): Slide[] {
  * Shown after "Start Test" but before camera setup / device check.
  * Ensures users understand what the test involves before proceeding.
  */
-export function PreTestSlides({ mode, isStarMode = false, onComplete, onSkip }: PreTestSlidesProps) {
+export function PreTestSlides({
+  mode,
+  isStarMode = false,
+  onComplete,
+  onSkip,
+}: PreTestSlidesProps) {
   const slides = getSlides(mode, isStarMode);
   const [currentSlide, setCurrentSlide] = useState(0);
   const [direction, setDirection] = useState(1); // 1 = forward, -1 = backward
@@ -288,15 +326,15 @@ export function PreTestSlides({ mode, isStarMode = false, onComplete, onSkip }: 
         <button
           type="button"
           onClick={onSkip}
-          className="absolute top-6 right-6 text-xs text-[#A09890] hover:text-[#6B6560] transition-colors"
+          className="absolute top-6 right-6 text-xs text-[#A09890] transition-colors hover:text-[#6B6560]"
         >
           Skip introduction →
         </button>
       )}
 
       {/* Slide content */}
-      <div className="flex flex-col items-center w-full max-w-5xl px-8 md:px-12">
-        <LexoraLogo size="md" className="mb-12 opacity-60 absolute top-8 left-8" />
+      <div className="flex w-full max-w-5xl flex-col items-center px-8 md:px-12">
+        <LexoraLogo size="md" className="absolute top-8 left-8 mb-12 opacity-60" />
 
         <AnimatePresence mode="wait" custom={direction}>
           <motion.div
@@ -306,37 +344,40 @@ export function PreTestSlides({ mode, isStarMode = false, onComplete, onSkip }: 
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0, x: -direction * 80 }}
             transition={{ duration: 0.4, ease: 'easeOut' }}
-            className="flex flex-col md:flex-row items-center justify-center gap-12 md:gap-24 w-full h-[60vh]"
+            className="flex h-[60vh] w-full flex-col items-center justify-center gap-12 md:flex-row md:gap-24"
           >
             {/* Left: Large Animated Visual */}
-            <div className="flex-1 flex justify-center items-center h-full">
-              <div className="relative w-64 h-64 md:w-96 md:h-96 rounded-3xl overflow-hidden border border-[#E8E0D4] shadow-sm">
+            <div className="flex h-full flex-1 items-center justify-center">
+              <div className="relative h-64 w-64 overflow-hidden rounded-3xl border border-[#E8E0D4] shadow-sm md:h-96 md:w-96">
                 {slide.visual}
               </div>
             </div>
 
             {/* Right: Text Content */}
-            <div className="flex-1 flex flex-col items-start text-left gap-6">
-              <h2 className="text-4xl md:text-5xl font-extrabold text-[#2D2A26] tracking-tight leading-tight">
+            <div className="flex flex-1 flex-col items-start gap-6 text-left">
+              <h2 className="text-4xl leading-tight font-extrabold tracking-tight text-[#2D2A26] md:text-5xl">
                 {slide.title}
               </h2>
-              
-              <p className="text-lg md:text-xl text-[#6B6560] leading-relaxed">
+
+              <p className="text-lg leading-relaxed text-[#6B6560] md:text-xl">
                 {slide.description}
               </p>
 
               {slide.highlight && (
-                <p className="text-lg font-semibold text-[#4A7C59] bg-[#4A7C59]/10 px-4 py-2 rounded-lg">
+                <p className="rounded-lg bg-[#4A7C59]/10 px-4 py-2 text-lg font-semibold text-[#4A7C59]">
                   {slide.highlight}
                 </p>
               )}
 
               {slide.tips && slide.tips.length > 0 && (
-                <div className="w-full rounded-2xl border-2 border-[#E8E0D4] bg-white/80 p-6 md:p-8 mt-2 shadow-sm">
+                <div className="mt-2 w-full rounded-2xl border-2 border-[#E8E0D4] bg-white/80 p-6 shadow-sm md:p-8">
                   <ul className="space-y-4">
                     {slide.tips.map((tip, idx) => (
-                      <li key={idx} className="flex items-start gap-4 text-base md:text-lg text-[#6B6560]">
-                        <span className="mt-0.5 shrink-0 flex items-center justify-center w-6 h-6 rounded-full bg-[#4A7C59]/20 text-[#4A7C59] font-bold text-sm">
+                      <li
+                        key={idx}
+                        className="flex items-start gap-4 text-base text-[#6B6560] md:text-lg"
+                      >
+                        <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[#4A7C59]/20 text-sm font-bold text-[#4A7C59]">
                           ✓
                         </span>
                         <span className="font-medium">{tip}</span>
@@ -351,7 +392,7 @@ export function PreTestSlides({ mode, isStarMode = false, onComplete, onSkip }: 
       </div>
 
       {/* Navigation controls */}
-      <div className="absolute bottom-8 left-0 right-0 flex flex-col items-center gap-4">
+      <div className="absolute right-0 bottom-8 left-0 flex flex-col items-center gap-4">
         {/* Dot indicators */}
         <div className="flex items-center gap-2">
           {slides.map((_, idx) => (
@@ -364,9 +405,7 @@ export function PreTestSlides({ mode, isStarMode = false, onComplete, onSkip }: 
               }}
               className={cn(
                 'h-2 rounded-full transition-all duration-300',
-                idx === currentSlide
-                  ? 'w-6 bg-[#4A7C59]'
-                  : 'w-2 bg-[#D4CBBD] hover:bg-[#A09890]',
+                idx === currentSlide ? 'w-6 bg-[#4A7C59]' : 'w-2 bg-[#D4CBBD] hover:bg-[#A09890]',
               )}
               aria-label={`Go to slide ${idx + 1}`}
             />
@@ -385,10 +424,7 @@ export function PreTestSlides({ mode, isStarMode = false, onComplete, onSkip }: 
               Back
             </Button>
           )}
-          <Button
-            onClick={goNext}
-            className="bg-[#4A7C59] text-white hover:bg-[#3D6A4B] px-8"
-          >
+          <Button onClick={goNext} className="bg-[#4A7C59] px-8 text-white hover:bg-[#3D6A4B]">
             {isLast ? (
               <>
                 I&apos;m Ready

--- a/web/src/features/test/components/pre-test-slides.tsx
+++ b/web/src/features/test/components/pre-test-slides.tsx
@@ -7,6 +7,7 @@ import {
   Monitor,
   BookOpen,
   Sun,
+  Star,
   Shield,
   ArrowRight,
   ArrowLeft,
@@ -19,6 +20,8 @@ import { cn } from '@/lib/utils';
 interface PreTestSlidesProps {
   /** Test mode — affects slide content */
   mode: 'tobii' | 'webcam';
+  /** Whether the test is using the kid-friendly star calibration mode */
+  isStarMode?: boolean;
   /** Called when user completes the slides */
   onComplete: () => void;
   /** Called when user wants to skip */
@@ -72,6 +75,33 @@ const CalibrationVisual = () => (
          animate={{ scale: [0.3, 1, 0.3] }} 
          transition={{ duration: 1.5, repeat: Infinity }} 
        />
+    </motion.div>
+  </div>
+);
+
+const StarGameVisual = () => (
+  <div className="relative w-full h-full bg-amber-500/5">
+    <div className="absolute w-4 h-4 bg-amber-500/30 rounded-full" style={{ top: '15%', left: '15%', transform: 'translate(-50%, -50%)' }} />
+    <div className="absolute w-4 h-4 bg-amber-500/30 rounded-full" style={{ top: '15%', left: '85%', transform: 'translate(-50%, -50%)' }} />
+    <div className="absolute w-4 h-4 bg-amber-500/30 rounded-full" style={{ top: '85%', left: '15%', transform: 'translate(-50%, -50%)' }} />
+    <div className="absolute w-4 h-4 bg-amber-500/30 rounded-full" style={{ top: '85%', left: '85%', transform: 'translate(-50%, -50%)' }} />
+    
+    <motion.div 
+      className="absolute w-16 h-16 flex items-center justify-center text-amber-400 drop-shadow-md"
+      style={{ x: '-50%', y: '-50%' }}
+      animate={{ 
+        top: ['15%', '15%', '85%', '85%', '50%'],
+        left: ['15%', '85%', '15%', '85%', '50%'],
+        scale: [1, 0.2, 1, 0.2, 1, 0.2, 1, 0.2, 1]
+      }}
+      transition={{ duration: 8, repeat: Infinity, ease: 'easeInOut' }}
+    >
+       <motion.div
+         animate={{ rotate: [0, 5, 0, -5, 0] }}
+         transition={{ duration: 1.2, repeat: Infinity, ease: 'easeInOut' }}
+       >
+         <Star className="w-16 h-16 fill-amber-400/80" />
+       </motion.div>
     </motion.div>
   </div>
 );
@@ -133,7 +163,32 @@ const PrivacyVisual = () => (
   </div>
 );
 
-function getSlides(mode: 'tobii' | 'webcam'): Slide[] {
+function getSlides(mode: 'tobii' | 'webcam', isStarMode: boolean): Slide[] {
+  const whatYoullDoSlide: Slide = isStarMode
+    ? {
+        visual: <StarGameVisual />,
+        title: 'Catch the Stars!',
+        description: 'Look directly at the glowing stars when they appear on the screen. They will magically shrink and vanish when you catch them with your eyes!',
+        tips: [
+          'Keep your eyes fixed on the star until it disappears',
+          'Have fun and try to catch all of them!',
+          'After the stars, just read the short story naturally',
+        ],
+      }
+    : {
+        visual: <CalibrationVisual />,
+        title: 'What You\'ll Do',
+        description:
+          mode === 'tobii'
+            ? 'Follow the dots to calibrate, then complete 3 short reading tasks.'
+            : 'Follow the dots to calibrate, then read a short paragraph naturally.',
+        tips: [
+          'Follow the calibration dots with your eyes',
+          'Read the text naturally — don\'t rush',
+          'Get instant results immediately after',
+        ],
+      };
+
   const common: Slide[] = [
     {
       visual: <WelcomeVisual />,
@@ -142,19 +197,7 @@ function getSlides(mode: 'tobii' | 'webcam'): Slide[] {
         'We analyze your eye movements while you read to screen for signs of dyslexia. Non-invasive, quick, and research-backed.',
       highlight: 'The whole process takes about 5 minutes.',
     },
-    {
-      visual: <CalibrationVisual />,
-      title: 'What You\'ll Do',
-      description:
-        mode === 'tobii'
-          ? 'Follow the dots to calibrate, then complete 3 short reading tasks.'
-          : 'Follow the dots to calibrate, then read a short paragraph naturally.',
-      tips: [
-        'Follow the calibration dots with your eyes',
-        'Read the text naturally — don\'t rush',
-        'Get instant results immediately after',
-      ],
-    },
+    whatYoullDoSlide,
     {
       visual: <PositionVisual />,
       title: 'Prepare Your Space',
@@ -213,8 +256,8 @@ function getSlides(mode: 'tobii' | 'webcam'): Slide[] {
  * Shown after "Start Test" but before camera setup / device check.
  * Ensures users understand what the test involves before proceeding.
  */
-export function PreTestSlides({ mode, onComplete, onSkip }: PreTestSlidesProps) {
-  const slides = getSlides(mode);
+export function PreTestSlides({ mode, isStarMode = false, onComplete, onSkip }: PreTestSlidesProps) {
+  const slides = getSlides(mode, isStarMode);
   const [currentSlide, setCurrentSlide] = useState(0);
   const [direction, setDirection] = useState(1); // 1 = forward, -1 = backward
 

--- a/web/src/features/test/components/pre-test-slides.tsx
+++ b/web/src/features/test/components/pre-test-slides.tsx
@@ -51,18 +51,19 @@ const WelcomeVisual = () => (
 );
 
 const CalibrationVisual = () => (
-  <div className="relative w-full h-full p-8 bg-[#4A7C59]/5">
-    <div className="absolute top-8 left-8 w-4 h-4 bg-[#4A7C59]/30 rounded-full" />
-    <div className="absolute top-8 right-8 w-4 h-4 bg-[#4A7C59]/30 rounded-full" />
-    <div className="absolute bottom-8 left-8 w-4 h-4 bg-[#4A7C59]/30 rounded-full" />
-    <div className="absolute bottom-8 right-8 w-4 h-4 bg-[#4A7C59]/30 rounded-full" />
+  <div className="relative w-full h-full bg-[#4A7C59]/5">
+    <div className="absolute w-4 h-4 bg-[#4A7C59]/30 rounded-full" style={{ top: '15%', left: '15%', transform: 'translate(-50%, -50%)' }} />
+    <div className="absolute w-4 h-4 bg-[#4A7C59]/30 rounded-full" style={{ top: '15%', left: '85%', transform: 'translate(-50%, -50%)' }} />
+    <div className="absolute w-4 h-4 bg-[#4A7C59]/30 rounded-full" style={{ top: '85%', left: '15%', transform: 'translate(-50%, -50%)' }} />
+    <div className="absolute w-4 h-4 bg-[#4A7C59]/30 rounded-full" style={{ top: '85%', left: '85%', transform: 'translate(-50%, -50%)' }} />
     
     <motion.div 
       className="absolute w-8 h-8 rounded-full border-4 border-[#4A7C59] flex items-center justify-center bg-white shadow-md"
+      style={{ x: '-50%', y: '-50%' }}
       animate={{ 
-        top: ['2rem', '2rem', 'calc(100% - 3rem)', 'calc(100% - 3rem)', '50%'],
-        left: ['2rem', 'calc(100% - 3rem)', '2rem', 'calc(100% - 3rem)', '50%'],
-        scale: [1, 0.7, 1, 0.7, 1, 0.7, 1, 0.7, 1]
+        top: ['15%', '15%', '85%', '85%', '50%'],
+        left: ['15%', '85%', '15%', '85%', '50%'],
+        scale: [1, 0.6, 1, 0.6, 1, 0.6, 1, 0.6, 1]
       }}
       transition={{ duration: 6, repeat: Infinity, ease: 'easeInOut' }}
     >

--- a/web/src/features/test/components/pre-test-slides.tsx
+++ b/web/src/features/test/components/pre-test-slides.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  Eye,
+  Monitor,
+  BookOpen,
+  Sun,
+  Shield,
+  ArrowRight,
+  ArrowLeft,
+  ChevronRight,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { LexoraLogo } from '@/components/shared/lexora-logo';
+import { cn } from '@/lib/utils';
+
+interface PreTestSlidesProps {
+  /** Test mode — affects slide content */
+  mode: 'tobii' | 'webcam';
+  /** Called when user completes the slides */
+  onComplete: () => void;
+  /** Called when user wants to skip */
+  onSkip?: () => void;
+}
+
+interface Slide {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  tips?: string[];
+  highlight?: string;
+}
+
+function getSlides(mode: 'tobii' | 'webcam'): Slide[] {
+  const common: Slide[] = [
+    {
+      icon: <Eye className="w-10 h-10" />,
+      title: 'Welcome to Lexora',
+      description:
+        'Lexora uses eye-tracking technology to screen for signs of dyslexia by analysing how your eyes move while reading. This is a non-invasive, research-backed screening — not a medical diagnosis.',
+      highlight: 'The whole process takes about 5 minutes.',
+    },
+    {
+      icon: <BookOpen className="w-10 h-10" />,
+      title: 'What You\'ll Do',
+      description:
+        mode === 'tobii'
+          ? 'You\'ll go through 3 simple steps: calibration (following dots on screen), then 3 short reading tasks — syllables, pseudo-words, and a paragraph of text.'
+          : 'You\'ll go through 3 simple steps: calibration (following dots on screen), then a short reading task — reading a paragraph of text naturally.',
+      tips: [
+        'Follow the calibration dots with your eyes only',
+        'Read the text naturally — don\'t rush or skip',
+        'Results appear immediately after the reading tasks',
+      ],
+    },
+    {
+      icon: <Sun className="w-10 h-10" />,
+      title: 'Prepare Your Environment',
+      description: 'Good conditions make a big difference in accuracy.',
+      tips: [
+        'Sit at arm\'s length from the screen',
+        'Make sure your face is evenly lit — avoid bright light behind you',
+        'Remove glasses if possible to reduce reflections',
+        'Close other browser tabs to improve performance',
+        mode === 'webcam'
+          ? 'Ensure your webcam is clean and unobstructed'
+          : 'Ensure your Tobii device is connected and positioned correctly',
+      ],
+    },
+  ];
+
+  const modeSpecific: Slide =
+    mode === 'webcam'
+      ? {
+          icon: <Monitor className="w-10 h-10" />,
+          title: 'How Webcam Tracking Works',
+          description:
+            'Lexora uses your webcam to detect your iris position through a face-mesh AI model. The video feed is processed entirely in your browser — no images are ever sent to any server.',
+          tips: [
+            'Camera permission is required — we\'ll ask when you proceed',
+            'No video is recorded or stored',
+            'Only abstract eye coordinates are used for analysis',
+          ],
+        }
+      : {
+          icon: <Monitor className="w-10 h-10" />,
+          title: 'How Tobii Tracking Works',
+          description:
+            'Your Tobii eye tracker sends precise gaze coordinates to the local Lexora service running on your computer. All data stays on your machine during tracking.',
+          tips: [
+            'Make sure the Tobii service is running (green status)',
+            'The device uses infrared — invisible and safe',
+            'Tobii provides higher accuracy than webcam tracking',
+          ],
+        };
+
+  const privacySlide: Slide = {
+    icon: <Shield className="w-10 h-10" />,
+    title: 'Your Privacy',
+    description:
+      'Lexora is designed with privacy first. No personal data is collected — only abstract gaze coordinates.',
+    tips: [
+      'No video recordings or face images are stored',
+      'No names, emails, or personal identifiers collected',
+      'Data exists only during the active session',
+      'Closing the browser destroys all session data',
+    ],
+  };
+
+  return [...common, modeSpecific, privacySlide];
+}
+
+/**
+ * Full-screen pre-test education slide deck.
+ * Shown after "Start Test" but before camera setup / device check.
+ * Ensures users understand what the test involves before proceeding.
+ */
+export function PreTestSlides({ mode, onComplete, onSkip }: PreTestSlidesProps) {
+  const slides = getSlides(mode);
+  const [currentSlide, setCurrentSlide] = useState(0);
+  const [direction, setDirection] = useState(1); // 1 = forward, -1 = backward
+
+  const isLast = currentSlide === slides.length - 1;
+
+  const goNext = useCallback(() => {
+    if (isLast) {
+      onComplete();
+    } else {
+      setDirection(1);
+      setCurrentSlide((prev) => prev + 1);
+    }
+  }, [isLast, onComplete]);
+
+  const goPrev = useCallback(() => {
+    if (currentSlide > 0) {
+      setDirection(-1);
+      setCurrentSlide((prev) => prev - 1);
+    }
+  }, [currentSlide]);
+
+  const slide = slides[currentSlide];
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-[#FDF8F0]">
+      {/* Skip button */}
+      {onSkip && (
+        <button
+          type="button"
+          onClick={onSkip}
+          className="absolute top-6 right-6 text-xs text-[#A09890] hover:text-[#6B6560] transition-colors"
+        >
+          Skip introduction →
+        </button>
+      )}
+
+      {/* Slide content */}
+      <div className="flex flex-col items-center max-w-lg px-6 text-center">
+        <LexoraLogo size="sm" className="mb-8 opacity-60" />
+
+        <AnimatePresence mode="wait" custom={direction}>
+          <motion.div
+            key={currentSlide}
+            custom={direction}
+            initial={{ opacity: 0, x: direction * 60 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -direction * 60 }}
+            transition={{ duration: 0.3, ease: 'easeInOut' }}
+            className="flex flex-col items-center gap-5"
+          >
+            {/* Icon */}
+            <div className="flex h-20 w-20 items-center justify-center rounded-2xl bg-[#4A7C59]/10 text-[#4A7C59]">
+              {slide.icon}
+            </div>
+
+            {/* Title */}
+            <h2 className="text-2xl font-bold text-[#2D2A26]">{slide.title}</h2>
+
+            {/* Description */}
+            <p className="text-sm text-[#6B6560] leading-relaxed">{slide.description}</p>
+
+            {/* Highlight */}
+            {slide.highlight && (
+              <p className="text-sm font-semibold text-[#4A7C59]">{slide.highlight}</p>
+            )}
+
+            {/* Tips */}
+            {slide.tips && slide.tips.length > 0 && (
+              <div className="w-full rounded-xl border border-[#E8E0D4] bg-white/60 p-4 text-left">
+                <ul className="space-y-2">
+                  {slide.tips.map((tip, idx) => (
+                    <li key={idx} className="flex items-start gap-2.5 text-sm text-[#6B6560]">
+                      <span className="mt-0.5 shrink-0 text-[#4A7C59] font-bold">✓</span>
+                      <span>{tip}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </motion.div>
+        </AnimatePresence>
+      </div>
+
+      {/* Navigation controls */}
+      <div className="absolute bottom-8 left-0 right-0 flex flex-col items-center gap-4">
+        {/* Dot indicators */}
+        <div className="flex items-center gap-2">
+          {slides.map((_, idx) => (
+            <button
+              key={idx}
+              type="button"
+              onClick={() => {
+                setDirection(idx > currentSlide ? 1 : -1);
+                setCurrentSlide(idx);
+              }}
+              className={cn(
+                'h-2 rounded-full transition-all duration-300',
+                idx === currentSlide
+                  ? 'w-6 bg-[#4A7C59]'
+                  : 'w-2 bg-[#D4CBBD] hover:bg-[#A09890]',
+              )}
+              aria-label={`Go to slide ${idx + 1}`}
+            />
+          ))}
+        </div>
+
+        {/* Buttons */}
+        <div className="flex items-center gap-3">
+          {currentSlide > 0 && (
+            <Button
+              variant="outline"
+              onClick={goPrev}
+              className="border-[#D4CBBD] text-[#6B6560] hover:text-[#2D2A26]"
+            >
+              <ArrowLeft className="mr-1.5 h-4 w-4" />
+              Back
+            </Button>
+          )}
+          <Button
+            onClick={goNext}
+            className="bg-[#4A7C59] text-white hover:bg-[#3D6A4B] px-8"
+          >
+            {isLast ? (
+              <>
+                I&apos;m Ready
+                <ChevronRight className="ml-1.5 h-4 w-4" />
+              </>
+            ) : (
+              <>
+                Next
+                <ArrowRight className="ml-1.5 h-4 w-4" />
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/test/components/pre-test-slides.tsx
+++ b/web/src/features/test/components/pre-test-slides.tsx
@@ -26,24 +26,123 @@ interface PreTestSlidesProps {
 }
 
 interface Slide {
-  icon: React.ReactNode;
+  visual: React.ReactNode;
   title: string;
   description: string;
   tips?: string[];
   highlight?: string;
 }
 
+const WelcomeVisual = () => (
+  <div className="relative w-full h-full flex items-center justify-center bg-[#4A7C59]/5">
+    <motion.div 
+      className="w-24 h-24 border-4 border-[#4A7C59] rounded-full flex items-center justify-center relative shadow-sm bg-white"
+      initial={{ scale: 0.9 }}
+      animate={{ scale: 1 }}
+      transition={{ duration: 2, repeat: Infinity, repeatType: 'reverse', ease: 'easeInOut' }}
+    >
+      <motion.div 
+        className="w-8 h-8 bg-[#4A7C59] rounded-full shadow-inner"
+        animate={{ x: [-24, 24, -24, 0] }}
+        transition={{ duration: 4, repeat: Infinity, ease: 'easeInOut' }}
+      />
+    </motion.div>
+  </div>
+);
+
+const CalibrationVisual = () => (
+  <div className="relative w-full h-full p-8 bg-[#4A7C59]/5">
+    <div className="absolute top-8 left-8 w-4 h-4 bg-[#4A7C59]/30 rounded-full" />
+    <div className="absolute top-8 right-8 w-4 h-4 bg-[#4A7C59]/30 rounded-full" />
+    <div className="absolute bottom-8 left-8 w-4 h-4 bg-[#4A7C59]/30 rounded-full" />
+    <div className="absolute bottom-8 right-8 w-4 h-4 bg-[#4A7C59]/30 rounded-full" />
+    
+    <motion.div 
+      className="absolute w-8 h-8 rounded-full border-4 border-[#4A7C59] flex items-center justify-center bg-white shadow-md"
+      animate={{ 
+        top: ['2rem', '2rem', 'calc(100% - 3rem)', 'calc(100% - 3rem)', '50%'],
+        left: ['2rem', 'calc(100% - 3rem)', '2rem', 'calc(100% - 3rem)', '50%'],
+        scale: [1, 0.7, 1, 0.7, 1, 0.7, 1, 0.7, 1]
+      }}
+      transition={{ duration: 6, repeat: Infinity, ease: 'easeInOut' }}
+    >
+       <motion.div 
+         className="w-3 h-3 bg-[#4A7C59] rounded-full" 
+         animate={{ scale: [0.3, 1, 0.3] }} 
+         transition={{ duration: 1.5, repeat: Infinity }} 
+       />
+    </motion.div>
+  </div>
+);
+
+const PositionVisual = () => (
+  <div className="relative w-full h-full flex items-center justify-center bg-[#4A7C59]/5 overflow-hidden">
+    <div className="w-1/2 h-3/4 border-4 border-[#4A7C59]/30 rounded-2xl flex items-center justify-center bg-white shadow-sm">
+       <motion.div 
+         className="w-16 h-20 border-2 border-dashed border-[#4A7C59] rounded-[2rem]"
+         animate={{ scale: [0.9, 1.1, 1], opacity: [0.4, 1, 0.4] }}
+         transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
+       />
+    </div>
+    <motion.div 
+       className="absolute top-4 right-6 text-amber-400"
+       animate={{ rotate: 360, scale: [1, 1.2, 1] }}
+       transition={{ duration: 8, repeat: Infinity, ease: 'linear' }}
+    >
+       <Sun className="w-12 h-12 fill-amber-400/20" />
+    </motion.div>
+  </div>
+);
+
+const SecureVisual = () => (
+  <div className="relative w-full h-full flex flex-col items-center justify-center gap-6 bg-[#4A7C59]/5">
+     <Monitor className="w-16 h-16 text-[#4A7C59]" strokeWidth={1.5} />
+     <div className="flex gap-3">
+       {[0,1,2].map(i => (
+         <motion.div 
+           key={i}
+           className="w-2.5 h-2.5 bg-[#4A7C59] rounded-full"
+           animate={{ y: [0, -12, 0], opacity: [0.2, 1, 0.2] }}
+           transition={{ duration: 1.5, repeat: Infinity, delay: i * 0.2, ease: 'easeInOut' }}
+         />
+       ))}
+     </div>
+     <div className="relative">
+       <Shield className="w-12 h-12 text-[#4A7C59]" strokeWidth={1.5} />
+       <motion.div 
+         className="absolute inset-0 bg-[#4A7C59] rounded-full blur-xl -z-10"
+         animate={{ opacity: [0.1, 0.4, 0.1], scale: [0.8, 1.5, 0.8] }}
+         transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
+       />
+     </div>
+  </div>
+);
+
+const PrivacyVisual = () => (
+  <div className="relative w-full h-full flex items-center justify-center bg-[#4A7C59]/5">
+     <motion.div
+       animate={{ rotateY: [0, 180, 360] }}
+       transition={{ duration: 4, repeat: Infinity, ease: 'linear' }}
+       style={{ transformStyle: 'preserve-3d' }}
+     >
+       <Shield className="w-24 h-24 text-[#4A7C59] fill-[#4A7C59]/10" strokeWidth={1.5} />
+     </motion.div>
+     <motion.div className="absolute top-1/4 right-1/4 w-3 h-3 bg-[#4A7C59]/40 rounded-full" animate={{ scale: [0, 1.5, 0] }} transition={{ duration: 2, repeat: Infinity, delay: 0.5 }} />
+     <motion.div className="absolute bottom-1/4 left-1/4 w-4 h-4 bg-[#4A7C59]/40 rounded-full" animate={{ scale: [0, 1.5, 0] }} transition={{ duration: 2, repeat: Infinity, delay: 1.5 }} />
+  </div>
+);
+
 function getSlides(mode: 'tobii' | 'webcam'): Slide[] {
   const common: Slide[] = [
     {
-      icon: <Eye />,
+      visual: <WelcomeVisual />,
       title: 'Welcome to Lexora',
       description:
         'We analyze your eye movements while you read to screen for signs of dyslexia. Non-invasive, quick, and research-backed.',
       highlight: 'The whole process takes about 5 minutes.',
     },
     {
-      icon: <BookOpen />,
+      visual: <CalibrationVisual />,
       title: 'What You\'ll Do',
       description:
         mode === 'tobii'
@@ -56,7 +155,7 @@ function getSlides(mode: 'tobii' | 'webcam'): Slide[] {
       ],
     },
     {
-      icon: <Sun />,
+      visual: <PositionVisual />,
       title: 'Prepare Your Space',
       description: 'Good conditions ensure accurate tracking.',
       tips: [
@@ -71,7 +170,7 @@ function getSlides(mode: 'tobii' | 'webcam'): Slide[] {
   const modeSpecific: Slide =
     mode === 'webcam'
       ? {
-          icon: <Monitor />,
+          visual: <SecureVisual />,
           title: 'Secure Webcam Tracking',
           description:
             'Your webcam tracks your eyes securely entirely inside your browser. No video is ever sent to our servers.',
@@ -82,7 +181,7 @@ function getSlides(mode: 'tobii' | 'webcam'): Slide[] {
           ],
         }
       : {
-          icon: <Monitor />,
+          visual: <SecureVisual />,
           title: 'Secure Tobii Tracking',
           description:
             'Your local Tobii service tracks your eyes securely. All data stays entirely on your machine.',
@@ -94,7 +193,7 @@ function getSlides(mode: 'tobii' | 'webcam'): Slide[] {
         };
 
   const privacySlide: Slide = {
-    icon: <Shield />,
+    visual: <PrivacyVisual />,
     title: 'Your Privacy',
     description:
       'Privacy first. We do not collect personal identifiers, and data exists only during your active session.',
@@ -165,11 +264,10 @@ export function PreTestSlides({ mode, onComplete, onSkip }: PreTestSlidesProps) 
             transition={{ duration: 0.4, ease: 'easeOut' }}
             className="flex flex-col md:flex-row items-center justify-center gap-12 md:gap-24 w-full h-[60vh]"
           >
-            {/* Left: Large Visual Icon */}
-            <div className="flex-1 flex justify-center items-center">
-              <div className="relative w-56 h-56 md:w-80 md:h-80 rounded-[3rem] bg-[#4A7C59]/10 flex items-center justify-center overflow-hidden">
-                <div className="absolute inset-0 bg-gradient-to-tr from-[#4A7C59]/20 to-transparent opacity-50" />
-                {React.cloneElement(slide.icon as React.ReactElement, { className: "w-28 h-28 md:w-40 md:h-40 text-[#4A7C59] relative z-10" })}
+            {/* Left: Large Animated Visual */}
+            <div className="flex-1 flex justify-center items-center h-full">
+              <div className="relative w-64 h-64 md:w-96 md:h-96 rounded-3xl overflow-hidden border border-[#E8E0D4] shadow-sm">
+                {slide.visual}
               </div>
             </div>
 

--- a/web/src/features/test/components/pre-test-slides.tsx
+++ b/web/src/features/test/components/pre-test-slides.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Eye,
@@ -36,37 +36,34 @@ interface Slide {
 function getSlides(mode: 'tobii' | 'webcam'): Slide[] {
   const common: Slide[] = [
     {
-      icon: <Eye className="w-10 h-10" />,
+      icon: <Eye />,
       title: 'Welcome to Lexora',
       description:
-        'Lexora uses eye-tracking technology to screen for signs of dyslexia by analysing how your eyes move while reading. This is a non-invasive, research-backed screening — not a medical diagnosis.',
+        'We analyze your eye movements while you read to screen for signs of dyslexia. Non-invasive, quick, and research-backed.',
       highlight: 'The whole process takes about 5 minutes.',
     },
     {
-      icon: <BookOpen className="w-10 h-10" />,
+      icon: <BookOpen />,
       title: 'What You\'ll Do',
       description:
         mode === 'tobii'
-          ? 'You\'ll go through 3 simple steps: calibration (following dots on screen), then 3 short reading tasks — syllables, pseudo-words, and a paragraph of text.'
-          : 'You\'ll go through 3 simple steps: calibration (following dots on screen), then a short reading task — reading a paragraph of text naturally.',
+          ? 'Follow the dots to calibrate, then complete 3 short reading tasks.'
+          : 'Follow the dots to calibrate, then read a short paragraph naturally.',
       tips: [
-        'Follow the calibration dots with your eyes only',
-        'Read the text naturally — don\'t rush or skip',
-        'Results appear immediately after the reading tasks',
+        'Follow the calibration dots with your eyes',
+        'Read the text naturally — don\'t rush',
+        'Get instant results immediately after',
       ],
     },
     {
-      icon: <Sun className="w-10 h-10" />,
-      title: 'Prepare Your Environment',
-      description: 'Good conditions make a big difference in accuracy.',
+      icon: <Sun />,
+      title: 'Prepare Your Space',
+      description: 'Good conditions ensure accurate tracking.',
       tips: [
-        'Sit at arm\'s length from the screen',
-        'Make sure your face is evenly lit — avoid bright light behind you',
-        'Remove glasses if possible to reduce reflections',
-        'Close other browser tabs to improve performance',
-        mode === 'webcam'
-          ? 'Ensure your webcam is clean and unobstructed'
-          : 'Ensure your Tobii device is connected and positioned correctly',
+        'Sit directly at arm\'s length from the screen',
+        'Ensure even lighting — avoid bright backlight',
+        'Remove glasses if possible to reduce glare',
+        mode === 'webcam' ? 'Ensure your webcam is clean' : 'Ensure your Tobii is connected',
       ],
     },
   ];
@@ -74,38 +71,37 @@ function getSlides(mode: 'tobii' | 'webcam'): Slide[] {
   const modeSpecific: Slide =
     mode === 'webcam'
       ? {
-          icon: <Monitor className="w-10 h-10" />,
-          title: 'How Webcam Tracking Works',
+          icon: <Monitor />,
+          title: 'Secure Webcam Tracking',
           description:
-            'Lexora uses your webcam to detect your iris position through a face-mesh AI model. The video feed is processed entirely in your browser — no images are ever sent to any server.',
+            'Your webcam tracks your eyes securely entirely inside your browser. No video is ever sent to our servers.',
           tips: [
-            'Camera permission is required — we\'ll ask when you proceed',
+            'We will ask for Camera permission next',
             'No video is recorded or stored',
-            'Only abstract eye coordinates are used for analysis',
+            'Only abstract coordinates are used',
           ],
         }
       : {
-          icon: <Monitor className="w-10 h-10" />,
-          title: 'How Tobii Tracking Works',
+          icon: <Monitor />,
+          title: 'Secure Tobii Tracking',
           description:
-            'Your Tobii eye tracker sends precise gaze coordinates to the local Lexora service running on your computer. All data stays on your machine during tracking.',
+            'Your local Tobii service tracks your eyes securely. All data stays entirely on your machine.',
           tips: [
-            'Make sure the Tobii service is running (green status)',
-            'The device uses infrared — invisible and safe',
-            'Tobii provides higher accuracy than webcam tracking',
+            'Ensure the Tobii service is running (green)',
+            'Infrared tracking is invisible and safe',
+            'Provides higher accuracy for analysis',
           ],
         };
 
   const privacySlide: Slide = {
-    icon: <Shield className="w-10 h-10" />,
+    icon: <Shield />,
     title: 'Your Privacy',
     description:
-      'Lexora is designed with privacy first. No personal data is collected — only abstract gaze coordinates.',
+      'Privacy first. We do not collect personal identifiers, and data exists only during your active session.',
     tips: [
-      'No video recordings or face images are stored',
-      'No names, emails, or personal identifiers collected',
-      'Data exists only during the active session',
-      'Closing the browser destroys all session data',
+      'No video recordings or face images stored',
+      'No names or emails collected',
+      'Closing the browser destroys all data',
     ],
   };
 
@@ -156,48 +152,58 @@ export function PreTestSlides({ mode, onComplete, onSkip }: PreTestSlidesProps) 
       )}
 
       {/* Slide content */}
-      <div className="flex flex-col items-center max-w-lg px-6 text-center">
-        <LexoraLogo size="sm" className="mb-8 opacity-60" />
+      <div className="flex flex-col items-center w-full max-w-5xl px-8 md:px-12">
+        <LexoraLogo size="md" className="mb-12 opacity-60 absolute top-8 left-8" />
 
         <AnimatePresence mode="wait" custom={direction}>
           <motion.div
             key={currentSlide}
             custom={direction}
-            initial={{ opacity: 0, x: direction * 60 }}
+            initial={{ opacity: 0, x: direction * 80 }}
             animate={{ opacity: 1, x: 0 }}
-            exit={{ opacity: 0, x: -direction * 60 }}
-            transition={{ duration: 0.3, ease: 'easeInOut' }}
-            className="flex flex-col items-center gap-5"
+            exit={{ opacity: 0, x: -direction * 80 }}
+            transition={{ duration: 0.4, ease: 'easeOut' }}
+            className="flex flex-col md:flex-row items-center justify-center gap-12 md:gap-24 w-full h-[60vh]"
           >
-            {/* Icon */}
-            <div className="flex h-20 w-20 items-center justify-center rounded-2xl bg-[#4A7C59]/10 text-[#4A7C59]">
-              {slide.icon}
+            {/* Left: Large Visual Icon */}
+            <div className="flex-1 flex justify-center items-center">
+              <div className="relative w-56 h-56 md:w-80 md:h-80 rounded-[3rem] bg-[#4A7C59]/10 flex items-center justify-center overflow-hidden">
+                <div className="absolute inset-0 bg-gradient-to-tr from-[#4A7C59]/20 to-transparent opacity-50" />
+                {React.cloneElement(slide.icon as React.ReactElement, { className: "w-28 h-28 md:w-40 md:h-40 text-[#4A7C59] relative z-10" })}
+              </div>
             </div>
 
-            {/* Title */}
-            <h2 className="text-2xl font-bold text-[#2D2A26]">{slide.title}</h2>
+            {/* Right: Text Content */}
+            <div className="flex-1 flex flex-col items-start text-left gap-6">
+              <h2 className="text-4xl md:text-5xl font-extrabold text-[#2D2A26] tracking-tight leading-tight">
+                {slide.title}
+              </h2>
+              
+              <p className="text-lg md:text-xl text-[#6B6560] leading-relaxed">
+                {slide.description}
+              </p>
 
-            {/* Description */}
-            <p className="text-sm text-[#6B6560] leading-relaxed">{slide.description}</p>
+              {slide.highlight && (
+                <p className="text-lg font-semibold text-[#4A7C59] bg-[#4A7C59]/10 px-4 py-2 rounded-lg">
+                  {slide.highlight}
+                </p>
+              )}
 
-            {/* Highlight */}
-            {slide.highlight && (
-              <p className="text-sm font-semibold text-[#4A7C59]">{slide.highlight}</p>
-            )}
-
-            {/* Tips */}
-            {slide.tips && slide.tips.length > 0 && (
-              <div className="w-full rounded-xl border border-[#E8E0D4] bg-white/60 p-4 text-left">
-                <ul className="space-y-2">
-                  {slide.tips.map((tip, idx) => (
-                    <li key={idx} className="flex items-start gap-2.5 text-sm text-[#6B6560]">
-                      <span className="mt-0.5 shrink-0 text-[#4A7C59] font-bold">✓</span>
-                      <span>{tip}</span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
+              {slide.tips && slide.tips.length > 0 && (
+                <div className="w-full rounded-2xl border-2 border-[#E8E0D4] bg-white/80 p-6 md:p-8 mt-2 shadow-sm">
+                  <ul className="space-y-4">
+                    {slide.tips.map((tip, idx) => (
+                      <li key={idx} className="flex items-start gap-4 text-base md:text-lg text-[#6B6560]">
+                        <span className="mt-0.5 shrink-0 flex items-center justify-center w-6 h-6 rounded-full bg-[#4A7C59]/20 text-[#4A7C59] font-bold text-sm">
+                          ✓
+                        </span>
+                        <span className="font-medium">{tip}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
           </motion.div>
         </AnimatePresence>
       </div>

--- a/web/src/features/test/components/supported-hardware.tsx
+++ b/web/src/features/test/components/supported-hardware.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import {
+  Monitor,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  ArrowRight,
+  Eye,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface SupportedHardwareProps {
+  onContinue: () => void;
+}
+
+interface DeviceInfo {
+  name: string;
+  type: 'screen-based' | 'portable';
+  status: 'supported' | 'legacy' | 'incompatible';
+  hz?: string;
+  note?: string;
+}
+
+const SUPPORTED_DEVICES: DeviceInfo[] = [
+  { name: 'Tobii Pro Spectrum', type: 'screen-based', status: 'supported', hz: 'Up to 1200 Hz' },
+  { name: 'Tobii Pro Fusion', type: 'screen-based', status: 'supported', hz: 'Up to 250 Hz' },
+  { name: 'Tobii Pro Spark', type: 'screen-based', status: 'supported', hz: '60 Hz' },
+  { name: 'Tobii Pro Nano', type: 'screen-based', status: 'supported', hz: '60 Hz' },
+];
+
+const LEGACY_DEVICES: DeviceInfo[] = [
+  { name: 'Tobii Pro X3-120', type: 'screen-based', status: 'legacy', hz: '120 Hz' },
+  { name: 'Tobii Pro X2-60', type: 'screen-based', status: 'legacy', hz: '60 Hz' },
+  { name: 'Tobii Pro X2-30', type: 'screen-based', status: 'legacy', hz: '30 Hz' },
+  { name: 'Tobii Pro TX300', type: 'screen-based', status: 'legacy', hz: '300 Hz', note: 'Firmware ≥ 1.0.0' },
+  { name: 'Tobii Pro T60 XL', type: 'screen-based', status: 'legacy', note: 'Firmware ≥ 2.0.0' },
+  { name: 'Tobii T60 / T120', type: 'screen-based', status: 'legacy', note: 'Firmware ≥ 2.0.0' },
+  { name: 'Tobii X60 / X120', type: 'screen-based', status: 'legacy', note: 'Firmware ≥ 2.0.0' },
+];
+
+const INCOMPATIBLE_DEVICES: DeviceInfo[] = [
+  { name: 'Tobii Eye Tracker 5', type: 'screen-based', status: 'incompatible', note: 'Consumer / gaming device' },
+  { name: 'Tobii Eye Tracker 5L', type: 'screen-based', status: 'incompatible', note: 'Consumer / gaming device' },
+  { name: 'Tobii Eye Tracker 4C', type: 'screen-based', status: 'incompatible', note: 'Consumer / gaming device' },
+  { name: 'Tobii Pro Glasses 2', type: 'portable', status: 'incompatible', note: 'Wearable – not supported' },
+  { name: 'Tobii Pro Glasses 3', type: 'portable', status: 'incompatible', note: 'Wearable – not supported' },
+  { name: 'VR Headsets (all)', type: 'portable', status: 'incompatible', note: 'Not supported' },
+];
+
+function StatusBadge({ status }: { status: DeviceInfo['status'] }) {
+  if (status === 'supported') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2.5 py-0.5 text-[11px] font-semibold text-emerald-800">
+        <CheckCircle2 className="h-3 w-3" /> Supported
+      </span>
+    );
+  }
+  if (status === 'legacy') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2.5 py-0.5 text-[11px] font-semibold text-amber-800">
+        <Clock className="h-3 w-3" /> Legacy
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-red-100 px-2.5 py-0.5 text-[11px] font-semibold text-red-800">
+      <XCircle className="h-3 w-3" /> Not Compatible
+    </span>
+  );
+}
+
+function DeviceRow({ device, index }: { device: DeviceInfo; index: number }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: index * 0.03 }}
+      className="flex items-center justify-between rounded-xl border border-border bg-background px-4 py-3 transition-colors hover:bg-muted/40"
+    >
+      <div className="flex items-center gap-3">
+        <Monitor className="h-4 w-4 text-muted-foreground" />
+        <div>
+          <p className="text-sm font-medium">{device.name}</p>
+          <div className="flex items-center gap-2">
+            {device.hz && (
+              <span className="text-[11px] text-muted-foreground">{device.hz}</span>
+            )}
+            {device.note && (
+              <span className="text-[11px] text-muted-foreground italic">{device.note}</span>
+            )}
+          </div>
+        </div>
+      </div>
+      <StatusBadge status={device.status} />
+    </motion.div>
+  );
+}
+
+/**
+ * Full-page supported hardware listing.
+ * Shown immediately after clicking the Tobii test button,
+ * before proceeding to device setup / calibration.
+ */
+export function SupportedHardware({ onContinue }: SupportedHardwareProps) {
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col items-center gap-8 py-8">
+      {/* Header */}
+      <motion.div
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="flex flex-col items-center gap-3 text-center"
+      >
+        <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10">
+          <Eye className="h-7 w-7 text-primary" />
+        </div>
+        <h1 className="text-2xl font-bold tracking-tight">Compatible Eye Trackers</h1>
+        <p className="max-w-lg text-sm text-muted-foreground leading-relaxed">
+          Lexora works with Tobii Pro screen-based eye trackers. Check that your device
+          is on the supported list before proceeding.
+        </p>
+      </motion.div>
+
+      {/* Supported (current) */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.1 }}
+        className="w-full"
+      >
+        <div className="mb-3 flex items-center gap-2">
+          <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+          <h2 className="text-sm font-semibold">Fully Supported</h2>
+          <span className="text-[11px] text-muted-foreground">(Current models)</span>
+        </div>
+        <div className="space-y-2">
+          {SUPPORTED_DEVICES.map((device, i) => (
+            <DeviceRow key={device.name} device={device} index={i} />
+          ))}
+        </div>
+      </motion.div>
+
+      {/* Legacy */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.2 }}
+        className="w-full"
+      >
+        <div className="mb-3 flex items-center gap-2">
+          <Clock className="h-4 w-4 text-amber-600" />
+          <h2 className="text-sm font-semibold">Legacy Devices</h2>
+          <span className="text-[11px] text-muted-foreground">(Discontinued — may still work)</span>
+        </div>
+        <div className="space-y-2">
+          {LEGACY_DEVICES.map((device, i) => (
+            <DeviceRow key={device.name} device={device} index={i + SUPPORTED_DEVICES.length} />
+          ))}
+        </div>
+      </motion.div>
+
+      {/* Incompatible */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.3 }}
+        className="w-full"
+      >
+        <div className="mb-3 flex items-center gap-2">
+          <XCircle className="h-4 w-4 text-red-500" />
+          <h2 className="text-sm font-semibold">Not Compatible</h2>
+        </div>
+        <div className="space-y-2">
+          {INCOMPATIBLE_DEVICES.map((device, i) => (
+            <DeviceRow
+              key={device.name}
+              device={device}
+              index={i + SUPPORTED_DEVICES.length + LEGACY_DEVICES.length}
+            />
+          ))}
+        </div>
+      </motion.div>
+
+      {/* Continue button */}
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.4 }}
+        className="flex w-full flex-col items-center gap-3 pt-2"
+      >
+        <Button size="lg" onClick={onContinue} className="gap-2 px-8">
+          I have a compatible device — Continue
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+        <p className="text-[11px] text-muted-foreground">
+          You can also use the webcam-based test if you don&apos;t have a Tobii device.
+        </p>
+      </motion.div>
+    </div>
+  );
+}

--- a/web/src/features/test/components/supported-hardware.tsx
+++ b/web/src/features/test/components/supported-hardware.tsx
@@ -1,14 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import {
-  Monitor,
-  CheckCircle2,
-  XCircle,
-  Clock,
-  ArrowRight,
-  Eye,
-} from 'lucide-react';
+import { Monitor, CheckCircle2, XCircle, Clock, ArrowRight, Eye } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 interface SupportedHardwareProps {
@@ -34,18 +27,49 @@ const LEGACY_DEVICES: DeviceInfo[] = [
   { name: 'Tobii Pro X3-120', type: 'screen-based', status: 'legacy', hz: '120 Hz' },
   { name: 'Tobii Pro X2-60', type: 'screen-based', status: 'legacy', hz: '60 Hz' },
   { name: 'Tobii Pro X2-30', type: 'screen-based', status: 'legacy', hz: '30 Hz' },
-  { name: 'Tobii Pro TX300', type: 'screen-based', status: 'legacy', hz: '300 Hz', note: 'Firmware ≥ 1.0.0' },
+  {
+    name: 'Tobii Pro TX300',
+    type: 'screen-based',
+    status: 'legacy',
+    hz: '300 Hz',
+    note: 'Firmware ≥ 1.0.0',
+  },
   { name: 'Tobii Pro T60 XL', type: 'screen-based', status: 'legacy', note: 'Firmware ≥ 2.0.0' },
   { name: 'Tobii T60 / T120', type: 'screen-based', status: 'legacy', note: 'Firmware ≥ 2.0.0' },
   { name: 'Tobii X60 / X120', type: 'screen-based', status: 'legacy', note: 'Firmware ≥ 2.0.0' },
 ];
 
 const INCOMPATIBLE_DEVICES: DeviceInfo[] = [
-  { name: 'Tobii Eye Tracker 5', type: 'screen-based', status: 'incompatible', note: 'Consumer / gaming device' },
-  { name: 'Tobii Eye Tracker 5L', type: 'screen-based', status: 'incompatible', note: 'Consumer / gaming device' },
-  { name: 'Tobii Eye Tracker 4C', type: 'screen-based', status: 'incompatible', note: 'Consumer / gaming device' },
-  { name: 'Tobii Pro Glasses 2', type: 'portable', status: 'incompatible', note: 'Wearable – not supported' },
-  { name: 'Tobii Pro Glasses 3', type: 'portable', status: 'incompatible', note: 'Wearable – not supported' },
+  {
+    name: 'Tobii Eye Tracker 5',
+    type: 'screen-based',
+    status: 'incompatible',
+    note: 'Consumer / gaming device',
+  },
+  {
+    name: 'Tobii Eye Tracker 5L',
+    type: 'screen-based',
+    status: 'incompatible',
+    note: 'Consumer / gaming device',
+  },
+  {
+    name: 'Tobii Eye Tracker 4C',
+    type: 'screen-based',
+    status: 'incompatible',
+    note: 'Consumer / gaming device',
+  },
+  {
+    name: 'Tobii Pro Glasses 2',
+    type: 'portable',
+    status: 'incompatible',
+    note: 'Wearable – not supported',
+  },
+  {
+    name: 'Tobii Pro Glasses 3',
+    type: 'portable',
+    status: 'incompatible',
+    note: 'Wearable – not supported',
+  },
   { name: 'VR Headsets (all)', type: 'portable', status: 'incompatible', note: 'Not supported' },
 ];
 
@@ -77,18 +101,16 @@ function DeviceRow({ device, index }: { device: DeviceInfo; index: number }) {
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: index * 0.03 }}
-      className="flex items-center justify-between rounded-xl border border-border bg-background px-4 py-3 transition-colors hover:bg-muted/40"
+      className="border-border bg-background hover:bg-muted/40 flex items-center justify-between rounded-xl border px-4 py-3 transition-colors"
     >
       <div className="flex items-center gap-3">
-        <Monitor className="h-4 w-4 text-muted-foreground" />
+        <Monitor className="text-muted-foreground h-4 w-4" />
         <div>
           <p className="text-sm font-medium">{device.name}</p>
           <div className="flex items-center gap-2">
-            {device.hz && (
-              <span className="text-[11px] text-muted-foreground">{device.hz}</span>
-            )}
+            {device.hz && <span className="text-muted-foreground text-[11px]">{device.hz}</span>}
             {device.note && (
-              <span className="text-[11px] text-muted-foreground italic">{device.note}</span>
+              <span className="text-muted-foreground text-[11px] italic">{device.note}</span>
             )}
           </div>
         </div>
@@ -112,13 +134,13 @@ export function SupportedHardware({ onContinue }: SupportedHardwareProps) {
         animate={{ opacity: 1, y: 0 }}
         className="flex flex-col items-center gap-3 text-center"
       >
-        <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10">
-          <Eye className="h-7 w-7 text-primary" />
+        <div className="bg-primary/10 flex h-14 w-14 items-center justify-center rounded-2xl">
+          <Eye className="text-primary h-7 w-7" />
         </div>
         <h1 className="text-2xl font-bold tracking-tight">Compatible Eye Trackers</h1>
-        <p className="max-w-lg text-sm text-muted-foreground leading-relaxed">
-          Lexora works with Tobii Pro screen-based eye trackers. Check that your device
-          is on the supported list before proceeding.
+        <p className="text-muted-foreground max-w-lg text-sm leading-relaxed">
+          Lexora works with Tobii Pro screen-based eye trackers. Check that your device is on the
+          supported list before proceeding.
         </p>
       </motion.div>
 
@@ -132,7 +154,7 @@ export function SupportedHardware({ onContinue }: SupportedHardwareProps) {
         <div className="mb-3 flex items-center gap-2">
           <CheckCircle2 className="h-4 w-4 text-emerald-600" />
           <h2 className="text-sm font-semibold">Fully Supported</h2>
-          <span className="text-[11px] text-muted-foreground">(Current models)</span>
+          <span className="text-muted-foreground text-[11px]">(Current models)</span>
         </div>
         <div className="space-y-2">
           {SUPPORTED_DEVICES.map((device, i) => (
@@ -151,7 +173,7 @@ export function SupportedHardware({ onContinue }: SupportedHardwareProps) {
         <div className="mb-3 flex items-center gap-2">
           <Clock className="h-4 w-4 text-amber-600" />
           <h2 className="text-sm font-semibold">Legacy Devices</h2>
-          <span className="text-[11px] text-muted-foreground">(Discontinued — may still work)</span>
+          <span className="text-muted-foreground text-[11px]">(Discontinued — may still work)</span>
         </div>
         <div className="space-y-2">
           {LEGACY_DEVICES.map((device, i) => (
@@ -193,7 +215,7 @@ export function SupportedHardware({ onContinue }: SupportedHardwareProps) {
           I have a compatible device — Continue
           <ArrowRight className="h-4 w-4" />
         </Button>
-        <p className="text-[11px] text-muted-foreground">
+        <p className="text-muted-foreground text-[11px]">
           You can also use the webcam-based test if you don&apos;t have a Tobii device.
         </p>
       </motion.div>

--- a/web/src/features/test/lib/test-machine.ts
+++ b/web/src/features/test/lib/test-machine.ts
@@ -40,7 +40,10 @@ export function createWebcamInitialState(): WebcamTestFlowState {
 function tobiiReducer(state: TobiiTestFlowState, action: TestAction): TobiiTestFlowState {
   switch (action.type) {
     case 'START':
-      return { ...state, currentState: 'device-check', error: null };
+      return { ...state, currentState: 'pre-test-education', error: null };
+
+    case 'EDUCATION_COMPLETE':
+      return { ...state, currentState: 'device-check' };
 
     case 'DEVICE_READY':
       return { ...state, currentState: 'calibrating' };
@@ -128,7 +131,10 @@ function tobiiReducer(state: TobiiTestFlowState, action: TestAction): TobiiTestF
 function webcamReducer(state: WebcamTestFlowState, action: TestAction): WebcamTestFlowState {
   switch (action.type) {
     case 'START':
-      return { ...state, currentState: 'camera-setup', error: null };
+      return { ...state, currentState: 'pre-test-education', error: null };
+
+    case 'EDUCATION_COMPLETE':
+      return { ...state, currentState: 'camera-setup' };
 
     case 'CAMERA_READY':
       return { ...state, currentState: 'calibrating' };

--- a/web/src/features/test/lib/test-machine.ts
+++ b/web/src/features/test/lib/test-machine.ts
@@ -10,7 +10,7 @@ import type {
 export function createTobiiInitialState(): TobiiTestFlowState {
   return {
     mode: 'tobii',
-    currentState: 'idle',
+    currentState: 'pre-test-education',
     calibration: null,
     taskData: {
       syllables: [],
@@ -25,7 +25,7 @@ export function createTobiiInitialState(): TobiiTestFlowState {
 export function createWebcamInitialState(): WebcamTestFlowState {
   return {
     mode: 'webcam',
-    currentState: 'idle',
+    currentState: 'pre-test-education',
     calibration: null,
     taskData: {
       paragraph: [],

--- a/web/src/features/test/lib/test-machine.ts
+++ b/web/src/features/test/lib/test-machine.ts
@@ -10,7 +10,7 @@ import type {
 export function createTobiiInitialState(): TobiiTestFlowState {
   return {
     mode: 'tobii',
-    currentState: 'pre-test-education',
+    currentState: 'idle',
     calibration: null,
     taskData: {
       syllables: [],
@@ -25,7 +25,7 @@ export function createTobiiInitialState(): TobiiTestFlowState {
 export function createWebcamInitialState(): WebcamTestFlowState {
   return {
     mode: 'webcam',
-    currentState: 'pre-test-education',
+    currentState: 'idle',
     calibration: null,
     taskData: {
       paragraph: [],

--- a/web/src/features/test/lib/test-machine.ts
+++ b/web/src/features/test/lib/test-machine.ts
@@ -35,7 +35,10 @@ export function createWebcamInitialState(): WebcamTestFlowState {
 function tobiiReducer(state: TobiiTestFlowState, action: TestAction): TobiiTestFlowState {
   switch (action.type) {
     case 'START':
-      return { ...state, currentState: 'pre-test-education', error: null };
+      return { ...state, currentState: 'hardware-check', error: null };
+
+    case 'HARDWARE_CONFIRMED':
+      return { ...state, currentState: 'pre-test-education' };
 
     case 'EDUCATION_COMPLETE':
       return { ...state, currentState: 'device-check' };

--- a/web/src/features/test/types.ts
+++ b/web/src/features/test/types.ts
@@ -78,6 +78,7 @@ export interface PredictionResult {
 // ─── Test Flow States ────────────────────────────────────
 export type TobiiTestState =
   | 'idle'
+  | 'pre-test-education'
   | 'device-check'
   | 'calibrating'
   | 'task-syllables'
@@ -92,6 +93,7 @@ export type TobiiTestState =
 
 export type WebcamTestState =
   | 'idle'
+  | 'pre-test-education'
   | 'camera-setup'
   | 'calibrating'
   | 'task-paragraph'
@@ -105,6 +107,7 @@ export type TestState = TobiiTestState | WebcamTestState;
 // ─── Test Flow Actions ───────────────────────────────────
 export type TestAction =
   | { type: 'START' }
+  | { type: 'EDUCATION_COMPLETE' }
   | { type: 'DEVICE_READY' }
   | { type: 'CAMERA_READY' }
   | { type: 'CALIBRATION_COMPLETE'; result: CalibrationResult }

--- a/web/src/features/test/types.ts
+++ b/web/src/features/test/types.ts
@@ -78,6 +78,7 @@ export interface PredictionResult {
 // ─── Test Flow States ────────────────────────────────────
 export type TobiiTestState =
   | 'idle'
+  | 'hardware-check'
   | 'pre-test-education'
   | 'device-check'
   | 'calibrating'
@@ -107,6 +108,7 @@ export type TestState = TobiiTestState | WebcamTestState;
 // ─── Test Flow Actions ───────────────────────────────────
 export type TestAction =
   | { type: 'START' }
+  | { type: 'HARDWARE_CONFIRMED' }
   | { type: 'EDUCATION_COMPLETE' }
   | { type: 'DEVICE_READY' }
   | { type: 'CAMERA_READY' }


### PR DESCRIPTION
(web): privacy rewrite, pre-test education slides & OS download buttons

- Full legal rewrite of privacy policy with GDPR structure, children's
  privacy, data subject rights, third-party disclosures, session-only model
- Add pre-test education slides (5 slides) shown after Start Test but
  before camera setup / device check — covers what the test does, tips,
  mode-specific explanation, and privacy assurance
- Add EDUCATION_COMPLETE action and pre-test-education state to both
  tobii and webcam state machines
- Add OS-specific download buttons section with auto-detection
  (Windows available, macOS/Linux 'Coming soon')
- Wire DownloadSection into landing page between How It Works and CTA"