### PR TITLE
fix(web): calibration UX - shrinking targets & distance guidance

### DIFF
--- a/web/src/features/test/components/calibration-modes/grid-mode-view.tsx
+++ b/web/src/features/test/components/calibration-modes/grid-mode-view.tsx
@@ -90,10 +90,10 @@ export function GridModeView({
       >
         {/* Shrinking container: starts at 80px, shrinks to 32px as fixation locks */}
         {(() => {
-          const maxSize = 80;
+          const maxSize = 160;
           const minSize = 0;
           const currentSize = maxSize - (maxSize - minSize) * fixationProgress;
-          const dotMaxSize = 16;
+          const dotMaxSize = 32;
           const dotMinSize = 0;
           const dotSize = dotMaxSize - (dotMaxSize - dotMinSize) * fixationProgress;
 

--- a/web/src/features/test/components/calibration-modes/grid-mode-view.tsx
+++ b/web/src/features/test/components/calibration-modes/grid-mode-view.tsx
@@ -71,7 +71,6 @@ export function GridModeView({
           );
         })}
 
-      {/* Active target — animates from previousPoint to currentPoint */}
       <motion.div
         key={`grid-target-${collectionStep}`}
         initial={{
@@ -89,69 +88,85 @@ export function GridModeView({
         transition={{ duration: motionDurationMs / 1000, ease: [0.4, 0, 0.2, 1] }}
         className="pointer-events-none absolute -translate-x-1/2 -translate-y-1/2"
       >
-        <div className="relative flex h-20 w-20 items-center justify-center rounded-full">
-          {/* Breathing glow */}
-          <motion.div
-            className={cn(
-              'absolute inset-0 rounded-full',
-              isStableFixation
-                ? 'bg-emerald-400/10 shadow-[0_0_28px_rgba(52,211,153,0.22)]'
-                : 'bg-[#4A7C59]/6 shadow-[0_0_18px_rgba(74,124,89,0.18)]',
-            )}
-            animate={{ scale: [1, 1.08, 1] }}
-            transition={{ duration: 2.2, repeat: Infinity, ease: 'easeInOut' }}
-          />
+        {/* Shrinking container: starts at 80px, shrinks to 32px as fixation locks */}
+        {(() => {
+          const maxSize = 80;
+          const minSize = 32;
+          const currentSize = maxSize - (maxSize - minSize) * fixationProgress;
+          const dotMaxSize = 16;
+          const dotMinSize = 6;
+          const dotSize = dotMaxSize - (dotMaxSize - dotMinSize) * fixationProgress;
 
-          {/* Outer ring */}
-          <div className="absolute inset-2 rounded-full border-2 border-[#4A7C59]/40 transition-colors duration-200" />
-
-          {/* Center dot — charcoal on cream */}
-          <div
-            className={cn(
-              'relative z-10 h-4 w-4 rounded-full transition-all duration-200',
-              isStableFixation
-                ? 'bg-emerald-500 shadow-[0_0_10px_rgba(52,211,153,0.5)]'
-                : 'bg-[#2D2A26] shadow-sm',
-            )}
-          />
-
-          {/* Progress arc ring */}
-          <svg className="absolute inset-0 h-full w-full -rotate-90" viewBox="0 0 100 100">
-            <circle
-              cx="50"
-              cy="50"
-              r="44"
-              fill="none"
-              stroke="rgba(74,124,89,0.10)"
-              strokeWidth="3"
-            />
-            <motion.circle
-              cx="50"
-              cy="50"
-              r="44"
-              fill="none"
-              stroke={isStableFixation ? '#10b981' : '#4A7C59'}
-              strokeWidth="3"
-              strokeLinecap="round"
-              strokeDasharray={276.5}
-              animate={{ strokeDashoffset: 276.5 * (1 - fixationProgress) }}
-              transition={{ duration: 0.09 }}
-            />
-          </svg>
-
-          {/* Capture ripple */}
-          <AnimatePresence>
-            {capturePulse && (
+          return (
+            <div
+              className="relative flex items-center justify-center rounded-full transition-[width,height] duration-100"
+              style={{ width: currentSize, height: currentSize }}
+            >
+              {/* Breathing glow */}
               <motion.div
-                initial={{ scale: 0.8, opacity: 0.5 }}
-                animate={{ scale: 2.2, opacity: 0 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.45, ease: 'easeOut' }}
-                className="absolute inset-0 rounded-full bg-emerald-400/15"
+                className={cn(
+                  'absolute inset-0 rounded-full',
+                  isStableFixation
+                    ? 'bg-emerald-400/10 shadow-[0_0_28px_rgba(52,211,153,0.22)]'
+                    : 'bg-[#4A7C59]/6 shadow-[0_0_18px_rgba(74,124,89,0.18)]',
+                )}
+                animate={{ scale: [1, 1.08, 1] }}
+                transition={{ duration: 2.2, repeat: Infinity, ease: 'easeInOut' }}
               />
-            )}
-          </AnimatePresence>
-        </div>
+
+              {/* Outer ring */}
+              <div className="absolute inset-[4px] rounded-full border-2 border-[#4A7C59]/40 transition-colors duration-200" />
+
+              {/* Center dot — shrinks with the container */}
+              <div
+                className={cn(
+                  'relative z-10 rounded-full transition-all duration-200',
+                  isStableFixation
+                    ? 'bg-emerald-500 shadow-[0_0_10px_rgba(52,211,153,0.5)]'
+                    : 'bg-[#2D2A26] shadow-sm',
+                )}
+                style={{ width: dotSize, height: dotSize }}
+              />
+
+              {/* Progress arc ring */}
+              <svg className="absolute inset-0 h-full w-full -rotate-90" viewBox="0 0 100 100">
+                <circle
+                  cx="50"
+                  cy="50"
+                  r="44"
+                  fill="none"
+                  stroke="rgba(74,124,89,0.10)"
+                  strokeWidth="3"
+                />
+                <motion.circle
+                  cx="50"
+                  cy="50"
+                  r="44"
+                  fill="none"
+                  stroke={isStableFixation ? '#10b981' : '#4A7C59'}
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                  strokeDasharray={276.5}
+                  animate={{ strokeDashoffset: 276.5 * (1 - fixationProgress) }}
+                  transition={{ duration: 0.09 }}
+                />
+              </svg>
+
+              {/* Capture ripple */}
+              <AnimatePresence>
+                {capturePulse && (
+                  <motion.div
+                    initial={{ scale: 0.8, opacity: 0.5 }}
+                    animate={{ scale: 2.2, opacity: 0 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.45, ease: 'easeOut' }}
+                    className="absolute inset-0 rounded-full bg-emerald-400/15"
+                  />
+                )}
+              </AnimatePresence>
+            </div>
+          );
+        })()}
       </motion.div>
 
       {/* Bottom HUD strip — outside calibration area */}

--- a/web/src/features/test/components/calibration-modes/grid-mode-view.tsx
+++ b/web/src/features/test/components/calibration-modes/grid-mode-view.tsx
@@ -91,10 +91,10 @@ export function GridModeView({
         {/* Shrinking container: starts at 80px, shrinks to 32px as fixation locks */}
         {(() => {
           const maxSize = 80;
-          const minSize = 32;
+          const minSize = 0;
           const currentSize = maxSize - (maxSize - minSize) * fixationProgress;
           const dotMaxSize = 16;
-          const dotMinSize = 6;
+          const dotMinSize = 0;
           const dotSize = dotMaxSize - (dotMaxSize - dotMinSize) * fixationProgress;
 
           return (
@@ -128,29 +128,6 @@ export function GridModeView({
                 style={{ width: dotSize, height: dotSize }}
               />
 
-              {/* Progress arc ring */}
-              <svg className="absolute inset-0 h-full w-full -rotate-90" viewBox="0 0 100 100">
-                <circle
-                  cx="50"
-                  cy="50"
-                  r="44"
-                  fill="none"
-                  stroke="rgba(74,124,89,0.10)"
-                  strokeWidth="3"
-                />
-                <motion.circle
-                  cx="50"
-                  cy="50"
-                  r="44"
-                  fill="none"
-                  stroke={isStableFixation ? '#10b981' : '#4A7C59'}
-                  strokeWidth="3"
-                  strokeLinecap="round"
-                  strokeDasharray={276.5}
-                  animate={{ strokeDashoffset: 276.5 * (1 - fixationProgress) }}
-                  transition={{ duration: 0.09 }}
-                />
-              </svg>
 
               {/* Capture ripple */}
               <AnimatePresence>

--- a/web/src/features/test/components/calibration-modes/star-mode-view.tsx
+++ b/web/src/features/test/components/calibration-modes/star-mode-view.tsx
@@ -92,9 +92,9 @@ export function StarModeView({
         {/* Shrinking container: starts at 96px, shrinks to 40px as fixation locks */}
         {(() => {
           const maxSize = 96;
-          const minSize = 40;
+          const minSize = 0;
           const currentSize = maxSize - (maxSize - minSize) * fixationProgress;
-          const starScale = 0.4 + 0.6 * (1 - fixationProgress); // star shrinks proportionally
+          const starScale = 1 - fixationProgress;
 
           return (
             <div
@@ -121,29 +121,7 @@ export function StarModeView({
                 <StarShape />
               </motion.div>
 
-              {/* Progress ring */}
-              <svg className="absolute inset-0 h-full w-full -rotate-90" viewBox="0 0 100 100">
-                <circle
-                  cx="50"
-                  cy="50"
-                  r="42"
-                  fill="none"
-                  stroke="rgba(245,158,11,0.12)"
-                  strokeWidth="3"
-                />
-                <motion.circle
-                  cx="50"
-                  cy="50"
-                  r="42"
-                  fill="none"
-                  stroke={isStableFixation ? '#10b981' : '#D97706'}
-                  strokeWidth="3"
-                  strokeLinecap="round"
-                  strokeDasharray={264}
-                  animate={{ strokeDashoffset: 264 * (1 - fixationProgress) }}
-                  transition={{ duration: 0.1 }}
-                />
-              </svg>
+
 
               {/* Capture feedback */}
               {capturePulse && (

--- a/web/src/features/test/components/calibration-modes/star-mode-view.tsx
+++ b/web/src/features/test/components/calibration-modes/star-mode-view.tsx
@@ -89,63 +89,75 @@ export function StarModeView({
         }}
         className="pointer-events-none absolute -translate-x-1/2 -translate-y-1/2"
       >
-        <div
-          className={cn(
-            'relative flex items-center justify-center rounded-full transition-all duration-200',
-            'h-24 w-24 border-2 border-amber-200/60 bg-amber-50/40',
-            capturePulse && 'scale-110',
-          )}
-        >
-          {/* Star with gentle wobble */}
-          <motion.div
-            animate={{
-              rotate: [0, 5, 0, -5, 0],
-              y: isStableFixation ? [0, -1, 0] : [0, -4, 0],
-            }}
-            transition={{
-              duration: isStableFixation ? 1.2 : 0.75,
-              repeat: Number.POSITIVE_INFINITY,
-              ease: 'easeInOut',
-            }}
-          >
-            <StarShape />
-          </motion.div>
+        {/* Shrinking container: starts at 96px, shrinks to 40px as fixation locks */}
+        {(() => {
+          const maxSize = 96;
+          const minSize = 40;
+          const currentSize = maxSize - (maxSize - minSize) * fixationProgress;
+          const starScale = 0.4 + 0.6 * (1 - fixationProgress); // star shrinks proportionally
 
-          {/* Progress ring */}
-          <svg className="absolute inset-0 h-full w-full -rotate-90" viewBox="0 0 100 100">
-            <circle
-              cx="50"
-              cy="50"
-              r="42"
-              fill="none"
-              stroke="rgba(245,158,11,0.12)"
-              strokeWidth="3"
-            />
-            <motion.circle
-              cx="50"
-              cy="50"
-              r="42"
-              fill="none"
-              stroke={isStableFixation ? '#10b981' : '#D97706'}
-              strokeWidth="3"
-              strokeLinecap="round"
-              strokeDasharray={264}
-              animate={{ strokeDashoffset: 264 * (1 - fixationProgress) }}
-              transition={{ duration: 0.1 }}
-            />
-          </svg>
-
-          {/* Capture feedback */}
-          {capturePulse && (
-            <motion.div
-              initial={{ opacity: 0, y: -2 }}
-              animate={{ opacity: 1, y: -14 }}
-              className="pointer-events-none absolute -top-7 rounded-md bg-amber-500 px-2.5 py-1 text-[11px] font-semibold text-white shadow-sm"
+          return (
+            <div
+              className={cn(
+                'relative flex items-center justify-center rounded-full transition-all duration-100',
+                'border-2 border-amber-200/60 bg-amber-50/40',
+                capturePulse && 'scale-110',
+              )}
+              style={{ width: currentSize, height: currentSize }}
             >
-              ✨ Got it!
-            </motion.div>
-          )}
-        </div>
+              {/* Star with gentle wobble — scales with shrinking */}
+              <motion.div
+                animate={{
+                  rotate: [0, 5, 0, -5, 0],
+                  y: isStableFixation ? [0, -1, 0] : [0, -4, 0],
+                }}
+                transition={{
+                  duration: isStableFixation ? 1.2 : 0.75,
+                  repeat: Number.POSITIVE_INFINITY,
+                  ease: 'easeInOut',
+                }}
+                style={{ transform: `scale(${starScale})` }}
+              >
+                <StarShape />
+              </motion.div>
+
+              {/* Progress ring */}
+              <svg className="absolute inset-0 h-full w-full -rotate-90" viewBox="0 0 100 100">
+                <circle
+                  cx="50"
+                  cy="50"
+                  r="42"
+                  fill="none"
+                  stroke="rgba(245,158,11,0.12)"
+                  strokeWidth="3"
+                />
+                <motion.circle
+                  cx="50"
+                  cy="50"
+                  r="42"
+                  fill="none"
+                  stroke={isStableFixation ? '#10b981' : '#D97706'}
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                  strokeDasharray={264}
+                  animate={{ strokeDashoffset: 264 * (1 - fixationProgress) }}
+                  transition={{ duration: 0.1 }}
+                />
+              </svg>
+
+              {/* Capture feedback */}
+              {capturePulse && (
+                <motion.div
+                  initial={{ opacity: 0, y: -2 }}
+                  animate={{ opacity: 1, y: -14 }}
+                  className="pointer-events-none absolute -top-7 rounded-md bg-amber-500 px-2.5 py-1 text-[11px] font-semibold text-white shadow-sm"
+                >
+                  ✨ Got it!
+                </motion.div>
+              )}
+            </div>
+          );
+        })()}
       </motion.div>
 
       {/* Bottom HUD strip — outside calibration area */}

--- a/web/src/features/test/components/calibration-modes/star-mode-view.tsx
+++ b/web/src/features/test/components/calibration-modes/star-mode-view.tsx
@@ -91,7 +91,7 @@ export function StarModeView({
       >
         {/* Shrinking container: starts at 96px, shrinks to 40px as fixation locks */}
         {(() => {
-          const maxSize = 96;
+          const maxSize = 200;
           const minSize = 0;
           const currentSize = maxSize - (maxSize - minSize) * fixationProgress;
           const starScale = 1 - fixationProgress;

--- a/web/src/features/test/components/camera-setup.tsx
+++ b/web/src/features/test/components/camera-setup.tsx
@@ -40,6 +40,8 @@ export function CameraSetup({ webcamGaze, videoRef, onReady }: CameraSetupProps)
   const [faceDetected, setFaceDetected] = useState(false);
   // Face position offset — null means no face, {x,y} normalized −1..1 from center
   const [faceOffset, setFaceOffset] = useState<{ x: number; y: number } | null>(null);
+  // Distance hint: 'too-close' | 'too-far' | 'good' | null
+  const [distanceHint, setDistanceHint] = useState<'too-close' | 'too-far' | 'good' | null>(null);
   const faceCheckRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
 
   const { cameraReady, modelReady, error, initCamera, initModel } = webcamGaze;
@@ -96,6 +98,7 @@ export function CameraSetup({ webcamGaze, videoRef, onReady }: CameraSetupProps)
       if (!iris) {
         setFaceDetected(false);
         setFaceOffset(null);
+        setDistanceHint(null);
         return;
       }
       setFaceDetected(true);
@@ -106,6 +109,20 @@ export function CameraSetup({ webcamGaze, videoRef, onReady }: CameraSetupProps)
       const offsetX = (centerX - 0.5) * 2;
       const offsetY = (centerY - 0.5) * 2;
       setFaceOffset({ x: offsetX, y: offsetY });
+
+      // Distance estimation: iris vertical spread as proxy for face size.
+      // Larger spread = closer to camera. Optimal: iris takes ~0.03-0.06 of frame.
+      const irisSpreadY = Math.abs(iris.leftY - iris.rightY);
+      const irisSpreadX = Math.abs(iris.leftX - iris.rightX);
+      const irisSize = Math.max(irisSpreadX, irisSpreadY);
+      // Use face Y coverage: if centerY spans a large range, face is close
+      if (irisSize > 0.12) {
+        setDistanceHint('too-close');
+      } else if (irisSize < 0.02) {
+        setDistanceHint('too-far');
+      } else {
+        setDistanceHint('good');
+      }
     }, 200);
     return () => {
       if (faceCheckRef.current) clearInterval(faceCheckRef.current);
@@ -163,6 +180,25 @@ export function CameraSetup({ webcamGaze, videoRef, onReady }: CameraSetupProps)
 
         {/* Face position guide overlay */}
         {cameraReady && <FaceGuideOverlay detected={faceDetected} offset={faceOffset} />}
+
+        {/* Distance guidance — drawn hand icons */}
+        {cameraReady && faceDetected && distanceHint && distanceHint !== 'good' && (
+          <div className="absolute bottom-6 left-1/2 -translate-x-1/2 flex items-center gap-3 rounded-xl bg-black/60 px-5 py-3 backdrop-blur-sm">
+            <span className="text-2xl" role="img" aria-label="hand">
+              {distanceHint === 'too-close' ? '🤚' : '👋'}
+            </span>
+            <div className="text-white">
+              <p className="text-sm font-semibold">
+                {distanceHint === 'too-close' ? 'Move back a little' : 'Move closer'}
+              </p>
+              <p className="text-[11px] text-white/60">
+                {distanceHint === 'too-close'
+                  ? 'You\'re too close — sit at arm\'s length'
+                  : 'Move closer to the screen for better tracking'}
+              </p>
+            </div>
+          </div>
+        )}
 
         {/* Live badge + camera name */}
         {cameraReady && (

--- a/web/src/features/test/hooks/use-calibration-engine.ts
+++ b/web/src/features/test/hooks/use-calibration-engine.ts
@@ -101,7 +101,7 @@ export function useCalibrationEngine({
     () => resolveCalibrationMode(mode, participantAge),
     [mode, participantAge],
   );
-  const requiredStableFixationMs = resolvedMode === 'grid' ? STABLE_FIXATION_MS : 120;
+  const requiredStableFixationMs = resolvedMode === 'grid' ? STABLE_FIXATION_MS : STABLE_FIXATION_MS * 0.85;
   const stableVelocityThreshold =
     resolvedMode === 'grid' ? STABLE_VELOCITY_NORM_PER_SEC : STABLE_VELOCITY_NORM_PER_SEC * 1.5;
 

--- a/web/src/features/test/lib/calibration-engine-constants.ts
+++ b/web/src/features/test/lib/calibration-engine-constants.ts
@@ -48,12 +48,12 @@ export const COUNTDOWN_SECONDS = envNumber('NEXT_PUBLIC_CALIBRATION_COUNTDOWN_SE
  *
  * Research consensus (Rayner 2009, Holmqvist 2017) recommends 250-350ms
  * for reliable fixation detection. However, for a calibration sequence,
- * a longer dwell time (e.g. 1200ms) provides better visual feedback (slow shrinking animation)
- * and forces a very high quality, intentional fixation.
+ * a slightly longer dwell time (e.g. 600ms) provides better visual feedback (shrinking animation)
+ * without feeling too slow or tedious.
  *
- * Env: NEXT_PUBLIC_STABLE_FIXATION_MS (default: 1200)
+ * Env: NEXT_PUBLIC_STABLE_FIXATION_MS (default: 600)
  */
-export const STABLE_FIXATION_MS = envNumber('NEXT_PUBLIC_STABLE_FIXATION_MS', 1200);
+export const STABLE_FIXATION_MS = envNumber('NEXT_PUBLIC_STABLE_FIXATION_MS', 600);
 
 /**
  * Maximum velocity (normalized to screen diagonal per second) at which

--- a/web/src/features/test/lib/calibration-engine-constants.ts
+++ b/web/src/features/test/lib/calibration-engine-constants.ts
@@ -47,12 +47,13 @@ export const COUNTDOWN_SECONDS = envNumber('NEXT_PUBLIC_CALIBRATION_COUNTDOWN_SE
  * Minimum stable fixation duration (ms) before accepting a sample.
  *
  * Research consensus (Rayner 2009, Holmqvist 2017) recommends 250-350ms
- * for reliable fixation detection. 200ms is too short — allows samples
- * during microsaccades. 300ms filters these while remaining responsive.
+ * for reliable fixation detection. However, for a calibration sequence,
+ * a longer dwell time (e.g. 1200ms) provides better visual feedback (slow shrinking animation)
+ * and forces a very high quality, intentional fixation.
  *
- * Env: NEXT_PUBLIC_STABLE_FIXATION_MS (default: 300)
+ * Env: NEXT_PUBLIC_STABLE_FIXATION_MS (default: 1200)
  */
-export const STABLE_FIXATION_MS = envNumber('NEXT_PUBLIC_STABLE_FIXATION_MS', 300);
+export const STABLE_FIXATION_MS = envNumber('NEXT_PUBLIC_STABLE_FIXATION_MS', 1200);
 
 /**
  * Maximum velocity (normalized to screen diagonal per second) at which


### PR DESCRIPTION
- Implement shrinking calibration targets: both grid and star mode targets progressively shrink (80→32px grid, 96→40px star) as fixationProgress increases, providing visual 'lock-on' feedback
- Add hand gesture distance guidance to camera setup: detects face distance via iris spread and shows push-away/beckon-closer hand icons when user is too close or too far from the screen
- Center dots also shrink proportionally with their containers