### PR TITLE
Fix/UI design alignment

### DIFF
--- a/web/src/app/(marketing)/_components/landing-stage.tsx
+++ b/web/src/app/(marketing)/_components/landing-stage.tsx
@@ -142,12 +142,12 @@ export function LandingStage() {
       </div>
 
       <div className="absolute right-5 bottom-24 hidden w-lg max-w-[42vw] md:block">
-        <div className="relative h-80 overflow-hidden border border-[#e3dcc2]/25 bg-[#e3dcc2]/92 p-6 shadow-2xl shadow-[#1b2021]/35">
-          <div className="mb-6 flex items-center justify-between text-xs font-black tracking-[0.22em] text-[#51513d] uppercase">
+        <div className="relative h-80 overflow-hidden border border-[#e3dcc2]/25 bg-[#e3dcc2]/92 p-5 shadow-2xl shadow-[#1b2021]/35">
+          <div className="mb-4 flex items-center justify-between text-xs font-black tracking-[0.22em] text-[#51513d] uppercase">
             <span>Calibration field</span>
-            <span>15 points</span>
+            <span>20 points</span>
           </div>
-          <div className="relative space-y-6 font-serif text-2xl leading-none tracking-[0.18em] text-[#1b2021]/24">
+          <div className="relative z-10 space-y-4 font-serif text-xl leading-none tracking-[0.18em] text-[#1b2021]/24">
             {WORDS.map((word, index) => (
               <div key={word} className="flex justify-between">
                 <span>{word}</span>

--- a/web/src/app/(marketing)/_components/landing-stage.tsx
+++ b/web/src/app/(marketing)/_components/landing-stage.tsx
@@ -142,12 +142,12 @@ export function LandingStage() {
       </div>
 
       <div className="absolute right-5 bottom-24 hidden w-lg max-w-[42vw] md:block">
-        <div className="relative h-80 overflow-hidden border border-[#e3dcc2]/25 bg-[#e3dcc2]/92 p-5 shadow-2xl shadow-[#1b2021]/35">
-          <div className="mb-4 flex items-center justify-between text-xs font-black tracking-[0.22em] text-[#51513d] uppercase">
+        <div className="relative h-80 overflow-hidden border border-[#e3dcc2]/25 bg-[#e3dcc2]/92 p-6 shadow-2xl shadow-[#1b2021]/35">
+          <div className="mb-6 flex items-center justify-between text-xs font-black tracking-[0.22em] text-[#51513d] uppercase">
             <span>Calibration field</span>
             <span>20 points</span>
           </div>
-          <div className="relative z-10 space-y-4 font-serif text-xl leading-none tracking-[0.18em] text-[#1b2021]/24">
+          <div className="relative z-10 space-y-2 font-serif text-lg leading-none tracking-[0.18em] text-[#1b2021]/24">
             {WORDS.map((word, index) => (
               <div key={word} className="flex justify-between">
                 <span>{word}</span>

--- a/web/src/app/(marketing)/_components/landing-stage.tsx
+++ b/web/src/app/(marketing)/_components/landing-stage.tsx
@@ -147,9 +147,9 @@ export function LandingStage() {
             <span>Calibration field</span>
             <span>20 points</span>
           </div>
-          <div className="relative z-10 space-y-2 font-serif text-lg leading-none tracking-[0.18em] text-[#1b2021]/24">
+          <div className="relative z-10 space-y-4 font-serif text-2xl leading-none tracking-widest text-[#1b2021]/24">
             {WORDS.map((word, index) => (
-              <div key={word} className="flex justify-between">
+              <div key={word} className="flex justify-around">
                 <span>{word}</span>
                 <span>{WORDS[(index + 2) % WORDS.length]}</span>
                 <span>{WORDS[(index + 4) % WORDS.length]}</span>
@@ -157,66 +157,68 @@ export function LandingStage() {
             ))}
           </div>
 
-          <svg className="absolute inset-0 h-full w-full" aria-hidden="true">
-            <motion.path
-              d="M 42 92 C 126 68, 202 114, 294 82 S 430 96, 488 128 C 378 178, 214 118, 92 180 S 328 236, 462 212 C 346 280, 184 238, 56 302"
-              fill="none"
-              stroke="#51513d"
-              strokeWidth="3"
-              strokeLinecap="round"
-              strokeDasharray="8 11"
-              initial={{ pathLength: 0 }}
-              animate={{ pathLength: 1 }}
-              transition={{
-                duration: 4,
-                repeat: Infinity,
-                repeatType: 'mirror',
-                ease: 'easeInOut',
-              }}
-            />
-            <motion.path
-              d="M 58 126 C 156 102, 260 144, 390 110"
-              fill="none"
-              stroke="#a6a867"
-              strokeWidth="10"
-              strokeLinecap="round"
-              opacity=".42"
-              initial={{ pathLength: 0 }}
-              animate={{ pathLength: 1 }}
-              transition={{ duration: 2.5, repeat: Infinity, ease: 'easeInOut' }}
-            />
-          </svg>
+          <div className="pointer-events-none absolute inset-0 origin-center scale-[0.8]">
+            <svg className="absolute inset-0 h-full w-full" aria-hidden="true">
+              <motion.path
+                d="M 42 92 C 126 68, 202 114, 294 82 S 430 96, 488 128 C 378 178, 214 118, 92 180 S 328 236, 462 212 C 346 280, 184 238, 56 302"
+                fill="none"
+                stroke="#51513d"
+                strokeWidth="3"
+                strokeLinecap="round"
+                strokeDasharray="8 11"
+                initial={{ pathLength: 0 }}
+                animate={{ pathLength: 1 }}
+                transition={{
+                  duration: 4,
+                  repeat: Infinity,
+                  repeatType: 'mirror',
+                  ease: 'easeInOut',
+                }}
+              />
+              <motion.path
+                d="M 58 126 C 156 102, 260 144, 390 110"
+                fill="none"
+                stroke="#a6a867"
+                strokeWidth="10"
+                strokeLinecap="round"
+                opacity=".42"
+                initial={{ pathLength: 0 }}
+                animate={{ pathLength: 1 }}
+                transition={{ duration: 2.5, repeat: Infinity, ease: 'easeInOut' }}
+              />
+            </svg>
 
-          {[
-            [14, 25, 17, '#a6a867'],
-            [34, 29, 12, '#e3dc95'],
-            [52, 27, 21, '#51513d'],
-            [73, 38, 14, '#a6a867'],
-            [28, 58, 24, '#51513d'],
-            [50, 66, 13, '#1b2021'],
-            [76, 75, 19, '#a6a867'],
-            [16, 82, 15, '#e3dc95'],
-          ].map(([left, top, size, color], index) => (
-            <motion.span
-              key={`${left}-${top}`}
-              className="absolute rounded-full border-2 border-[#e3dcc2]/80 mix-blend-multiply"
-              style={{
-                left: `${left}%`,
-                top: `${top}%`,
-                width: size,
-                height: size,
-                backgroundColor: color as string,
-              }}
-              animate={{ scale: [0.86, 1.18, 0.86], opacity: [0.68, 1, 0.68] }}
-              transition={{
-                duration: 1.9 + index * 0.12,
-                repeat: Infinity,
-                delay: index * 0.12,
-              }}
-            />
-          ))}
+            {[
+              [14, 25, 17, '#a6a867'],
+              [34, 29, 12, '#e3dc95'],
+              [52, 27, 21, '#51513d'],
+              [73, 38, 14, '#a6a867'],
+              [28, 58, 24, '#51513d'],
+              [50, 66, 13, '#1b2021'],
+              [76, 75, 19, '#a6a867'],
+              [16, 82, 15, '#e3dc95'],
+            ].map(([left, top, size, color], index) => (
+              <motion.span
+                key={`${left}-${top}`}
+                className="absolute rounded-full border-2 border-[#e3dcc2]/80 mix-blend-multiply"
+                style={{
+                  left: `${left}%`,
+                  top: `${top}%`,
+                  width: size,
+                  height: size,
+                  backgroundColor: color as string,
+                }}
+                animate={{ scale: [0.86, 1.18, 0.86], opacity: [0.68, 1, 0.68] }}
+                transition={{
+                  duration: 1.9 + index * 0.12,
+                  repeat: Infinity,
+                  delay: index * 0.12,
+                }}
+              />
+            ))}
+          </div>
 
-          <div className="absolute right-5 bottom-5 left-5 grid grid-cols-3 gap-2 text-[10px] font-black tracking-[0.18em] uppercase">
+          <div className="absolute right-5 bottom-5 left-5 z-20 grid grid-cols-3 gap-2 text-[10px] font-black tracking-[0.18em] uppercase">
             <div className="bg-[#1b2021] px-3 py-3 text-[#e3dcc2]">Syllables</div>
             <div className="bg-[#51513d] px-3 py-3 text-[#e3dcc2]">Pseudo-words</div>
             <div className="bg-[#a6a867] px-3 py-3 text-[#1b2021]">Meaningful text</div>

--- a/web/src/app/(marketing)/_components/navbar.tsx
+++ b/web/src/app/(marketing)/_components/navbar.tsx
@@ -194,7 +194,7 @@ export function Navbar() {
             />
             {/* Panel */}
             <motion.div
-              className="fixed top-16 right-0 bottom-0 z-40 w-72 border-l border-[#51513d]/18 bg-[#e3dcc2] shadow-xl sm:hidden"
+              className="fixed top-16 right-0 bottom-0 z-40 w-72 border-l border-[#51513d]/25 bg-[#e3dcc2] shadow-xl sm:hidden"
               initial={{ x: '100%' }}
               animate={{ x: 0 }}
               exit={{ x: '100%' }}
@@ -208,8 +208,8 @@ export function Navbar() {
                       onClick={() => scrollTo(link.href)}
                       className={`cursor-pointer rounded-lg px-4 py-3 text-left text-sm font-medium transition-colors ${
                         isLinkActive(link)
-                          ? 'bg-[#51513d]/10 text-[#1b2021]'
-                          : 'text-[#1b2021]/70 hover:bg-[#51513d]/5 hover:text-[#1b2021]'
+                          ? 'bg-[#a6a867]/20 text-[#1b2021]'
+                          : 'text-[#1b2021]/70 hover:bg-[#51513d]/10 hover:text-[#1b2021]'
                       }`}
                     >
                       {link.label}
@@ -221,15 +221,15 @@ export function Navbar() {
                       onClick={() => setMobileOpen(false)}
                       className={`rounded-lg px-4 py-3 text-left text-sm font-medium transition-colors ${
                         isLinkActive(link)
-                          ? 'bg-[#51513d]/10 text-[#1b2021]'
-                          : 'text-[#1b2021]/70 hover:bg-[#51513d]/5 hover:text-[#1b2021]'
+                          ? 'bg-[#a6a867]/20 text-[#1b2021]'
+                          : 'text-[#1b2021]/70 hover:bg-[#51513d]/10 hover:text-[#1b2021]'
                       }`}
                     >
                       {link.label}
                     </Link>
                   ),
                 )}
-                <div className="my-2 border-t border-[#51513d]/18" />
+                <div className="my-2 border-t" />
                 <div className="px-4">
                   <UserNav />
                 </div>

--- a/web/src/app/(marketing)/_components/navbar.tsx
+++ b/web/src/app/(marketing)/_components/navbar.tsx
@@ -6,7 +6,6 @@ import { usePathname } from 'next/navigation';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Menu, X } from 'lucide-react';
 import { LexoraLogo } from '@/components/shared/lexora-logo';
-import { ThemeToggle } from '@/components/shared/theme-toggle';
 import { UserNav } from '@/components/shared/user-nav';
 import { Button } from '@/components/ui/button';
 
@@ -157,7 +156,6 @@ export function Navbar() {
           </div>
 
           <div className="flex items-center gap-3">
-            <ThemeToggle />
             <Button
               variant="outline"
               size="sm"
@@ -196,7 +194,7 @@ export function Navbar() {
             />
             {/* Panel */}
             <motion.div
-              className="bg-background fixed top-16 right-0 bottom-0 z-40 w-72 border-l shadow-xl sm:hidden"
+              className="fixed top-16 right-0 bottom-0 z-40 w-72 border-l border-[#51513d]/18 bg-[#e3dcc2] shadow-xl sm:hidden"
               initial={{ x: '100%' }}
               animate={{ x: 0 }}
               exit={{ x: '100%' }}
@@ -210,8 +208,8 @@ export function Navbar() {
                       onClick={() => scrollTo(link.href)}
                       className={`cursor-pointer rounded-lg px-4 py-3 text-left text-sm font-medium transition-colors ${
                         isLinkActive(link)
-                          ? 'text-foreground bg-accent/10'
-                          : 'text-foreground hover:bg-muted'
+                          ? 'bg-[#51513d]/10 text-[#1b2021]'
+                          : 'text-[#1b2021]/70 hover:bg-[#51513d]/5 hover:text-[#1b2021]'
                       }`}
                     >
                       {link.label}
@@ -223,15 +221,15 @@ export function Navbar() {
                       onClick={() => setMobileOpen(false)}
                       className={`rounded-lg px-4 py-3 text-left text-sm font-medium transition-colors ${
                         isLinkActive(link)
-                          ? 'text-foreground bg-accent/10'
-                          : 'text-foreground hover:bg-muted'
+                          ? 'bg-[#51513d]/10 text-[#1b2021]'
+                          : 'text-[#1b2021]/70 hover:bg-[#51513d]/5 hover:text-[#1b2021]'
                       }`}
                     >
                       {link.label}
                     </Link>
                   ),
                 )}
-                <div className="my-2 border-t" />
+                <div className="my-2 border-t border-[#51513d]/18" />
                 <div className="px-4">
                   <UserNav />
                 </div>

--- a/web/src/app/(marketing)/about/page.tsx
+++ b/web/src/app/(marketing)/about/page.tsx
@@ -31,7 +31,7 @@ const PRINCIPLES = [
 ];
 
 const TIMELINE = [
-  ['Calibrate', 'A 15-point map aligns gaze with the reading area before the test begins.'],
+  ['Calibrate', 'A 20-point map aligns gaze with the reading area before the test begins.'],
   [
     'Read',
     'Tobii mode uses syllables, pseudo-words, and meaningful text. Webcam mode uses a paragraph task.',

--- a/web/src/app/(marketing)/page.tsx
+++ b/web/src/app/(marketing)/page.tsx
@@ -92,7 +92,7 @@ const PRODUCT_BEATS = [
   {
     icon: ScanEye,
     title: 'Calibrated before reading',
-    copy: 'The test starts with a 15-point gaze map so the reading area is measured before the child begins.',
+    copy: 'The test starts with a 20-point gaze map so the reading area is measured before the child begins.',
   },
   {
     icon: ClipboardCheck,

--- a/web/src/components/shared/user-nav.tsx
+++ b/web/src/components/shared/user-nav.tsx
@@ -85,33 +85,39 @@ export function UserNav() {
         </Button>
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent align="end" className="w-56">
+      <DropdownMenuContent
+        align="end"
+        className="w-56 border-[#51513d]/18 bg-[#e3dcc2] p-2 text-[#1b2021] shadow-[8px_8px_0_rgba(81,81,61,.14)]"
+      >
         <DropdownMenuLabel className="font-normal">
           <div className="flex flex-col gap-1">
-            {user.name && <p className="text-sm leading-none font-medium">{user.name}</p>}
-            <p className="text-muted-foreground text-xs leading-none">{user.email}</p>
+            {user.name && <p className="text-sm leading-none font-black">{user.name}</p>}
+            <p className="text-xs leading-none text-[#1b2021]/60">{user.email}</p>
           </div>
         </DropdownMenuLabel>
 
-        <DropdownMenuSeparator />
+        <DropdownMenuSeparator className="bg-[#51513d]/18" />
 
-        <DropdownMenuItem asChild>
-          <Link href="/history" className="cursor-pointer">
+        <DropdownMenuItem asChild className="cursor-pointer focus:bg-[#51513d]/10 focus:text-[#1b2021]">
+          <Link href="/history" className="flex w-full items-center">
             <History className="mr-2 h-4 w-4" />
             Test history
           </Link>
         </DropdownMenuItem>
 
         {isAdmin && (
-          <DropdownMenuItem asChild>
-            <Link href="/admin/dashboard" className="cursor-pointer">
+          <DropdownMenuItem asChild className="cursor-pointer focus:bg-[#51513d]/10 focus:text-[#1b2021]">
+            <Link href="/admin/dashboard" className="flex w-full items-center">
               <LayoutDashboard className="mr-2 h-4 w-4" />
               Admin dashboard
             </Link>
           </DropdownMenuItem>
         )}
 
-        <DropdownMenuItem onClick={handleSignOut} className="cursor-pointer">
+        <DropdownMenuItem
+          onClick={handleSignOut}
+          className="cursor-pointer focus:bg-[#51513d]/10 focus:text-[#1b2021]"
+        >
           <LogOut className="mr-2 h-4 w-4" />
           Sign out
         </DropdownMenuItem>

--- a/web/src/components/shared/user-nav.tsx
+++ b/web/src/components/shared/user-nav.tsx
@@ -85,40 +85,34 @@ export function UserNav() {
         </Button>
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent
-        align="end"
-        className="w-56 border-[#51513d]/18 bg-[#e3dcc2] p-2 text-[#1b2021] shadow-[8px_8px_0_rgba(81,81,61,.14)]"
-      >
+      <DropdownMenuContent align="end" className="w-56 border-[#51513d]/25 bg-[#e3dcc2] text-[#1b2021] shadow-xl shadow-[#1b2021]/10">
         <DropdownMenuLabel className="font-normal">
           <div className="flex flex-col gap-1">
-            {user.name && <p className="text-sm leading-none font-black">{user.name}</p>}
-            <p className="text-xs leading-none text-[#1b2021]/60">{user.email}</p>
+            {user.name && <p className="text-sm leading-none font-medium">{user.name}</p>}
+            <p className="text-[#1b2021]/60 text-xs leading-none">{user.email}</p>
           </div>
         </DropdownMenuLabel>
 
-        <DropdownMenuSeparator className="bg-[#51513d]/18" />
+        <DropdownMenuSeparator className="bg-[#51513d]/15" />
 
-        <DropdownMenuItem asChild className="cursor-pointer focus:bg-[#51513d]/10 focus:text-[#1b2021]">
-          <Link href="/history" className="flex w-full items-center">
-            <History className="mr-2 h-4 w-4" />
+        <DropdownMenuItem asChild className="focus:bg-[#51513d]/10 focus:text-[#1b2021]">
+          <Link href="/history" className="cursor-pointer">
+            <History className="mr-2 h-4 w-4 text-[#51513d]" />
             Test history
           </Link>
         </DropdownMenuItem>
 
         {isAdmin && (
-          <DropdownMenuItem asChild className="cursor-pointer focus:bg-[#51513d]/10 focus:text-[#1b2021]">
-            <Link href="/admin/dashboard" className="flex w-full items-center">
-              <LayoutDashboard className="mr-2 h-4 w-4" />
+          <DropdownMenuItem asChild className="focus:bg-[#51513d]/10 focus:text-[#1b2021]">
+            <Link href="/admin/dashboard" className="cursor-pointer">
+              <LayoutDashboard className="mr-2 h-4 w-4 text-[#51513d]" />
               Admin dashboard
             </Link>
           </DropdownMenuItem>
         )}
 
-        <DropdownMenuItem
-          onClick={handleSignOut}
-          className="cursor-pointer focus:bg-[#51513d]/10 focus:text-[#1b2021]"
-        >
-          <LogOut className="mr-2 h-4 w-4" />
+        <DropdownMenuItem onClick={handleSignOut} className="cursor-pointer focus:bg-[#51513d]/10 focus:text-[#1b2021]">
+          <LogOut className="mr-2 h-4 w-4 text-[#51513d]" />
           Sign out
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/web/src/components/shared/user-nav.tsx
+++ b/web/src/components/shared/user-nav.tsx
@@ -85,11 +85,14 @@ export function UserNav() {
         </Button>
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent align="end" className="w-56 border-[#51513d]/25 bg-[#e3dcc2] text-[#1b2021] shadow-xl shadow-[#1b2021]/10">
+      <DropdownMenuContent
+        align="end"
+        className="w-56 border-[#51513d]/25 bg-[#e3dcc2] text-[#1b2021] shadow-xl shadow-[#1b2021]/10"
+      >
         <DropdownMenuLabel className="font-normal">
           <div className="flex flex-col gap-1">
             {user.name && <p className="text-sm leading-none font-medium">{user.name}</p>}
-            <p className="text-[#1b2021]/60 text-xs leading-none">{user.email}</p>
+            <p className="text-xs leading-none text-[#1b2021]/60">{user.email}</p>
           </div>
         </DropdownMenuLabel>
 
@@ -111,7 +114,10 @@ export function UserNav() {
           </DropdownMenuItem>
         )}
 
-        <DropdownMenuItem onClick={handleSignOut} className="cursor-pointer focus:bg-[#51513d]/10 focus:text-[#1b2021]">
+        <DropdownMenuItem
+          onClick={handleSignOut}
+          className="cursor-pointer focus:bg-[#51513d]/10 focus:text-[#1b2021]"
+        >
           <LogOut className="mr-2 h-4 w-4 text-[#51513d]" />
           Sign out
         </DropdownMenuItem>


### PR DESCRIPTION
* **Dark Mode:** Removed the `ThemeToggle` component to enforce the default light-themed `#e3dcc2` aesthetics.
* **Mobile Navbar:** Overhauled the mobile sidebar styles, matching the active, hover, and background colors with the new design system parameters.
* **User Profile Dropdown:** Updated the avatar dropdown menu with proper styling and aligned interactive item backgrounds with the new color palette.
* **Calibration Text Layout:** Decreased line-height spacing on the landing page's mock calibration field to fit all text elements without container overflow, and elevated the z-index so the underlying line graphics no longer visually strike through the values.
* **Content Updates:** Bumped the displayed calibration field count from 15 points to 20 points.

*Note: This PR strictly addresses design alignment and CSS rendering. Content/text review is pending.*